### PR TITLE
added NULL cmd exception

### DIFF
--- a/oh_my_minishell/execute_commands.c
+++ b/oh_my_minishell/execute_commands.c
@@ -17,6 +17,8 @@ char *string_tolower(char *str)
 
 int which_command(char *cmd)
 {
+	if (cmd == NULL)
+		return (-1);
 	if (!ft_strncmp(string_tolower(cmd),"echo",10))
 		return (ECHO);
 	if (!ft_strncmp(string_tolower(cmd),"cd",10))
@@ -44,7 +46,7 @@ int execve_nopipe(int num_cmd, char **argv, t_setting *setting)
 	int pid;
 	int *pipe_fd;
 	int temp;
-	
+
 	pipe_fd = setting->pipe_fd;
 	if (num_cmd == LS)
 	{
@@ -192,7 +194,7 @@ int execve_pipe(int num_cmd, char **argv, t_setting *setting)
 	int pid;
 	int *pipe_fd;
 	int temp;
-	
+
 	pipe_fd = setting->pipe_fd;
 	if (num_cmd == LS)
 	{
@@ -344,7 +346,7 @@ int execve_pipe(int num_cmd, char **argv, t_setting *setting)
 int passing_to_stdout(char **one_cmd_splited, t_setting *setting)
 {
 	int num_cmd;
-	
+
 	if (-1 == (num_cmd = which_command(one_cmd_splited[0])))
 	{
 		printf("command not found: %s\n", one_cmd_splited[0]);
@@ -361,7 +363,7 @@ int passing_to_stdout(char **one_cmd_splited, t_setting *setting)
 int passing_to_pipe(char **one_cmd_splited, t_setting *setting)
 {
 	int num_cmd;
-	
+
 	if (-1 == (num_cmd = which_command(one_cmd_splited[0])))
 	{
 		printf("command not found: %s\n", one_cmd_splited[0]);
@@ -381,7 +383,7 @@ int execute_command(char **split_by_pipes, t_setting *setting)
 	char *one_cmd_trimed;
 	char **one_cmd_splited;
 	int i = 0;
-	
+
 	if (-1 == pipe(setting->pipe_fd))
 	{
 		printf("pipe error\n");
@@ -402,7 +404,7 @@ int execute_command(char **split_by_pipes, t_setting *setting)
 			printf("뒤에 파이프가 더 있다.\n");
 			passing_to_pipe(one_cmd_splited, setting);
 		}
-	
+
 		free_split(one_cmd_splited);
 		free(one_cmd_trimed);
 		i++;


### PR DESCRIPTION
프로그램 실행에서 만약 명령어가 space 만 들어갔을 때 생기는 문제점을 해결하고자 이 코드를 추가하였습니다.
ft_strtrim으로 명령어를 정제하면서 one_cmd_splited[0]에 NULL이 들어가는 경우, which_command에서 이 문자열을 사용하다 segfault를 일으킵니다.
그래서 저는 이 에러처리 코드를 넣었습니다.

함수 which_command 에 
	if (cmd == NULL)
		return (-1);
추가하였습니다.