### PR TITLE
added exit and pwd 2

### DIFF
--- a/oh_my_minishell/Makefile
+++ b/oh_my_minishell/Makefile
@@ -7,7 +7,7 @@ UTILS		= ./libft/ft_memset.c ./libft/ft_bzero.c  ./libft/ft_memcpy.c  ./libft/ft
 				 		./libft/ft_substr.c  ./libft/ft_strjoin.c  ./libft/ft_strtrim.c  ./libft/ft_split.c  ./libft/ft_itoa.c ./libft/ft_strmapi.c ./libft/ft_putchar_fd.c ./libft/ft_putstr_fd.c ./libft/ft_putendl_fd.c ./libft/ft_putnbr_fd.c\
 				 			./libft/ft_lstnew.c ./libft/ft_lstadd_front.c ./libft/ft_lstsize.c ./libft/ft_lstlast.c ./libft/ft_lstadd_back.c ./libft/ft_lstdelone.c ./libft/ft_lstclear.c ./libft/ft_lstiter.c ./libft/ft_lstmap.c\
 								./gnl/get_next_line.c ./gnl/get_next_line_utils.c
-SRCS		= main.c execute_commands.c get_commands_from_gnl.c print.c execute_echo.c utils_jikang.c
+SRCS		= main.c execute_commands.c get_commands_from_gnl.c print.c execute_echo.c execute_pwd.c execute_exit.c utils_jikang.c
 OBJS		= $(SRCS:.c=.o)
 OBJS_UTILS	= $(UTILS:.c=.o)
 CC			= gcc

--- a/oh_my_minishell/execute_commands.c
+++ b/oh_my_minishell/execute_commands.c
@@ -48,7 +48,7 @@ int execve_rw_endofpipe(int num_cmd, char **argv, char *one_cmd_trimed, t_settin
 	int i;
 
 	pipe_fd = setting->pipe_fd;
-	
+
 	if (num_cmd == GREP) // Grep을 단독으로 썼을 떄에 대해서는 따로 구별해야할 듯
 	{
 		if (-1 == (pid = fork()))
@@ -103,14 +103,7 @@ int execve_w_endofpipe(int num_cmd, char **argv, char *one_cmd_trimed, t_setting
 	}
 	if (num_cmd == PWD)
 	{
-		if (-1 == (pid = fork()))
-			return (-1);
-		if (pid == 0)
-			execve("/bin/pwd", argv, setting->envp);
-		else
-		{
-			wait(NULL);
-		}
+		execute_pwd();
 	}
 	if (num_cmd == EXPORT)
 	{
@@ -146,7 +139,7 @@ int execve_w_endofpipe(int num_cmd, char **argv, char *one_cmd_trimed, t_setting
 		}
 	}
 	if (num_cmd == EXIT) //built-in 함수 써야함
-		exit(0);
+		execute_exit(argv);
 	return (1);
 }
 
@@ -171,7 +164,7 @@ int	execve_rw_pipe(int num_cmd, char **argv, t_setting *setting)
 	int *pipe_fd;
 	int *pipe_fd2;
 	int dup_stdout;
-	
+
 	dup_stdout = dup(STDOUT_FILENO);
 	pipe_fd = setting->pipe_fd;
 	pipe_fd2 = setting->pipe_fd2;
@@ -199,7 +192,7 @@ int	execve_rw_pipe(int num_cmd, char **argv, t_setting *setting)
 			close(pipe_fd[READ]);
 			wait(NULL);
 			exit(0);
-			
+
 			// dup2(pipe_fd2[READ], STDIN_FILENO);
 			// close(pipe_fd2[WRTIE]);
 			// execve("/usr/bin/grep", argv, setting->envp);
@@ -347,7 +340,7 @@ int passing_to_stdout(char **one_cmd_splited, char *one_cmd_trimed, t_setting *s
 		printf("command not found: %s\n", one_cmd_splited[0]);
 		return (-1);
 	}
-	
+
 	if (which_typeof_command(num_cmd) == WRONLY)
 	{
 		if (-1 == flush_pipe_fd(setting))

--- a/oh_my_minishell/execute_exit.c
+++ b/oh_my_minishell/execute_exit.c
@@ -6,24 +6,32 @@
 /*   By: jikang <jikang@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/04 21:30:41 by jikang            #+#    #+#             */
-/*   Updated: 2021/01/06 19:29:31 by jikang           ###   ########.fr       */
+/*   Updated: 2021/01/06 23:43:51 by jikang           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
 /* 숫자만 있으면 1, 숫자 아닌 것도 있으면 0 */
-static int is_only_num(char *str)
+static int	is_numeric(char *str)
 {
-	int i;
+	int	len;
 
-	i = 0;
-	while (str[i] != '\0')
+	len = ft_strlen(str);
+	if (len == 0)
+		return (0);
+	else if (len == 1 && !ft_isdigit(str[0]))
+		return (0);
+	else
 	{
-		/* 숫자 아닌 것이 있으면 */
-		if (!ft_isdigit(str[i]))
-			return (0);
-		i++;
+		if (*str == '-' || *str == '+')
+			str++;
+		while (*str)
+		{
+			if (!ft_isdigit(*str))
+				return (0);
+			str++;
+		}
 	}
 	return (1);
 }
@@ -31,7 +39,7 @@ static int is_only_num(char *str)
 static void one_argv(char *argv)
 {
 	/* 숫자만 있냐 아니냐? 판단하기 */
-	if (is_only_num(argv))
+	if (is_numeric(argv))
 	{
 		ft_putendl_fd("exit", 1);
 		exit((unsigned char)ft_atoi(argv));
@@ -49,11 +57,12 @@ static void one_argv(char *argv)
 static void more_than_one_argv(char *argv)
 {
 	/* 숫자만 있냐 아니냐? 판단하기 */
-	if (is_only_num(argv))
+	if (is_numeric(argv))
 	{
 		ft_putendl_fd("exit", 1);
 		ft_putendl_fd("bash: exit: too many arguments", 1);
-		exit(1);
+		// exit(1); // <== 이 경우에는 종료 안됨 하지만 exitcode가 1이 되는 건 맞음.
+		get_param()->exit_status = 1;
 	}
 	else
 	{
@@ -77,7 +86,7 @@ void execute_exit(char **argv)
 	if (i == 1)
 	{
 		// printf("i: %i\n", i);
-		exit(EXIT_SUCCESS);
+		exit(get_param()->exit_status);
 	}
 	/* i = 2 일 경우, 명령어 제대로 들어옴 */
 	/* argv[2] 에 숫자가 아닌 문자가 하나라도 있다면 문자 취급 */

--- a/oh_my_minishell/execute_exit.c
+++ b/oh_my_minishell/execute_exit.c
@@ -1,0 +1,97 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   execute_exit.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jikang <jikang@student.42seoul.kr>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/01/04 21:30:41 by jikang            #+#    #+#             */
+/*   Updated: 2021/01/06 19:29:31 by jikang           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+/* 숫자만 있으면 1, 숫자 아닌 것도 있으면 0 */
+static int is_only_num(char *str)
+{
+	int i;
+
+	i = 0;
+	while (str[i] != '\0')
+	{
+		/* 숫자 아닌 것이 있으면 */
+		if (!ft_isdigit(str[i]))
+			return (0);
+		i++;
+	}
+	return (1);
+}
+
+static void one_argv(char *argv)
+{
+	/* 숫자만 있냐 아니냐? 판단하기 */
+	if (is_only_num(argv))
+	{
+		ft_putendl_fd("exit", 1);
+		exit((unsigned char)ft_atoi(argv));
+	}
+	else
+	{
+		ft_putendl_fd("exit", 1);
+		ft_putstr_fd("bash: exit: ", 1);
+		ft_putstr_fd(argv, 1);
+		ft_putendl_fd(": numeric argument required", 1);
+		exit(255);
+	}
+}
+
+static void more_than_one_argv(char *argv)
+{
+	/* 숫자만 있냐 아니냐? 판단하기 */
+	if (is_only_num(argv))
+	{
+		ft_putendl_fd("exit", 1);
+		ft_putendl_fd("bash: exit: too many arguments", 1);
+		exit(1);
+	}
+	else
+	{
+		ft_putendl_fd("exit", 1);
+		ft_putstr_fd("bash: exit: ", 1);
+		ft_putstr_fd(argv, 1);
+		ft_putendl_fd(": numeric argument required", 1);
+		exit(255);
+	}
+}
+
+void execute_exit(char **argv)
+{
+	int i;
+
+	i = 0;
+	// printf("argv[0]: %s\n", argv[0]);
+	while (argv[i] != NULL)
+		i++;
+	/* i = 1 일 경우, 명령어 제대로 들어옴 */
+	if (i == 1)
+	{
+		// printf("i: %i\n", i);
+		exit(EXIT_SUCCESS);
+	}
+	/* i = 2 일 경우, 명령어 제대로 들어옴 */
+	/* argv[2] 에 숫자가 아닌 문자가 하나라도 있다면 문자 취급 */
+	if (i == 2)
+	{
+		// printf("i: %i\n", i);
+		// printf("argv[1]: %s\n", argv[1]);
+		one_argv(argv[1]);
+	}
+	else
+	{
+		// printf("i: %i\n", i);
+		// printf("argv[1]: %s\n", argv[1]);
+		// printf("argv[2]: %s\n", argv[2]);
+		more_than_one_argv(argv[1]);
+	}
+}

--- a/oh_my_minishell/execute_pwd.c
+++ b/oh_my_minishell/execute_pwd.c
@@ -1,0 +1,28 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   execute_pwd.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jikang <jikang@student.42seoul.kr>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/01/04 21:00:50 by jikang            #+#    #+#             */
+/*   Updated: 2021/01/06 19:28:43 by jikang           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+/*
+** https://man7.org/linux/man-pages/man2/getcwd.2.html
+** char *getcwd(char *buf, size_t size);
+** getcwd 는 buf 가 NULL 이면, 동적할당을 해준다. 그래서 free 필요.
+*/
+
+void execute_pwd(void)
+{
+	char *pwd;
+
+	pwd = getcwd(NULL, 1024);
+	ft_putendl_fd(pwd, 1);
+	free(pwd);
+}

--- a/oh_my_minishell/execute_pwd.c
+++ b/oh_my_minishell/execute_pwd.c
@@ -6,7 +6,7 @@
 /*   By: jikang <jikang@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/04 21:00:50 by jikang            #+#    #+#             */
-/*   Updated: 2021/01/06 19:28:43 by jikang           ###   ########.fr       */
+/*   Updated: 2021/01/06 20:12:55 by jikang           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,9 @@ void execute_pwd(void)
 {
 	char *pwd;
 
-	pwd = getcwd(NULL, 1024);
-	ft_putendl_fd(pwd, 1);
+	if (!(pwd = getcwd(NULL, PATH_MAX)))
+		ft_putendl_fd(strerror(errno), 2);
+	else
+		ft_putendl_fd(pwd, 1);
 	free(pwd);
 }

--- a/oh_my_minishell/main.c
+++ b/oh_my_minishell/main.c
@@ -7,6 +7,8 @@ int main(int argc, char *argv[], char **envp)
 	t_setting setting;
 	setting.envp = envp;
 	char *line;
+	get_param()->exit_status = 0; // exit 할 때, error 코드 초기화
+
 	while (TRUE)
 	{
 		ft_putstr_fd("bash-3.2$ ", 1);

--- a/oh_my_minishell/minishell.h
+++ b/oh_my_minishell/minishell.h
@@ -3,6 +3,9 @@
 
 # include <stdio.h>
 # include <unistd.h>
+# include <limits.h>
+# include <errno.h>
+# include <string.h>
 # include "./libft/libft.h"
 # include "./gnl/get_next_line.h"
 # define READ 0
@@ -26,6 +29,10 @@
 # define RDONLY 0
 # define WRONLY 1
 # define RDWR 2
+
+typedef struct	s_data {
+	unsigned char	exit_status;
+}				t_data;
 
 typedef struct s_setting
 {
@@ -72,6 +79,7 @@ void execute_pwd(void);
 void execute_exit(char **argv);
 
 //utils_jikang.c
+t_data	*get_param();
 int		ft_is_whitespace(char c);
 
 #endif

--- a/oh_my_minishell/minishell.h
+++ b/oh_my_minishell/minishell.h
@@ -65,6 +65,12 @@ int		flush_pipe_fd(t_setting *setting);
 //execute_echo.c
 void	execute_echo(char *one_cmd_trimed);
 
+//execute_pwd.c
+void execute_pwd(void);
+
+//execute_exit.c
+void execute_exit(char **argv);
+
 //utils_jikang.c
 int		ft_is_whitespace(char c);
 

--- a/oh_my_minishell/utils_jikang.c
+++ b/oh_my_minishell/utils_jikang.c
@@ -1,5 +1,11 @@
 #include "minishell.h"
 
+t_data *get_param()
+{
+	static t_data param;
+	return (&param);
+}
+
 int	ft_is_whitespace(char c)
 {
 	return (c == ' ' || c == '\t' || c == '\v' || c == '\f'


### PR DESCRIPTION
머지 요청 : PWD, EXIT 구현 하였습니다.

- 추가된 파일:
1. execute_pwd.c
pwd를 빌트인 함수로 구현함.

2. execute_exit.c
본 프로그램인 minishell 을 exit할 때의 경우를 각각 argv의 갯수, 문자, 숫자, exitcode($?)를 고려하여 만듦. exitcode는 exit 한 후, bash에서 $?명령어로 확인 가능.

3. test_exit 폴더의 테스트 파일들
이 파일은 향후, $?를 구현할 때 이 테스트 파일들로 테스트를 할 수 있습니다.
 
- 변경된 파일: 

1. execute_echo.c
아직 -n 옵션을 추가하지 않았다는 주석 추가

2.Makefile, minishell.h
추가된 파일로 인한 함수 추가