### PR TITLE
added \$\? and added a global variable g_status

### DIFF
--- a/oh_my_minishell/execute_echo.c
+++ b/oh_my_minishell/execute_echo.c
@@ -94,5 +94,7 @@ void execute_echo(char *one_cmd_trimed)
 			}
 		}
 	}
-		ft_putchar_fd('\n', 1);
+	/* -n 옵션 들어갈 시 무시 */
+	ft_putchar_fd('\n', 1);
+	g_status = 0;
 }

--- a/oh_my_minishell/execute_exit.c
+++ b/oh_my_minishell/execute_exit.c
@@ -6,7 +6,7 @@
 /*   By: jikang <jikang@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/04 21:30:41 by jikang            #+#    #+#             */
-/*   Updated: 2021/01/06 23:43:51 by jikang           ###   ########.fr       */
+/*   Updated: 2021/01/07 22:18:13 by jikang           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,7 +62,7 @@ static void more_than_one_argv(char *argv)
 		ft_putendl_fd("exit", 1);
 		ft_putendl_fd("bash: exit: too many arguments", 1);
 		// exit(1); // <== 이 경우에는 종료 안됨 하지만 exitcode가 1이 되는 건 맞음.
-		get_param()->exit_status = 1;
+		g_status = 1 * 256;
 	}
 	else
 	{
@@ -86,7 +86,7 @@ void execute_exit(char **argv)
 	if (i == 1)
 	{
 		// printf("i: %i\n", i);
-		exit(get_param()->exit_status);
+		exit(g_status);
 	}
 	/* i = 2 일 경우, 명령어 제대로 들어옴 */
 	/* argv[2] 에 숫자가 아닌 문자가 하나라도 있다면 문자 취급 */

--- a/oh_my_minishell/execute_pwd.c
+++ b/oh_my_minishell/execute_pwd.c
@@ -6,7 +6,7 @@
 /*   By: jikang <jikang@student.42seoul.kr>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/04 21:00:50 by jikang            #+#    #+#             */
-/*   Updated: 2021/01/06 20:12:55 by jikang           ###   ########.fr       */
+/*   Updated: 2021/01/07 22:18:33 by jikang           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,8 +23,14 @@ void execute_pwd(void)
 	char *pwd;
 
 	if (!(pwd = getcwd(NULL, PATH_MAX)))
+	{
 		ft_putendl_fd(strerror(errno), 2);
+		g_status = 1 * 256;
+	}
 	else
+	{
 		ft_putendl_fd(pwd, 1);
+		g_status = 0;
+	}
 	free(pwd);
 }

--- a/oh_my_minishell/main.c
+++ b/oh_my_minishell/main.c
@@ -4,12 +4,12 @@
 int main(int argc, char *argv[], char **envp)
 {
 	t_list *cmds = NULL;
-	
+
 	minishell_init(argc, argv, envp);
 	catch_signals();
 	char *line;
 	get_param()->envp = envp;
-	get_param()->exit_status = 0; // exit 할 때, error 코드 초기화
+	g_status = 0; // $? 의 코드
 
 	while (TRUE)
 	{

--- a/oh_my_minishell/minishell.h
+++ b/oh_my_minishell/minishell.h
@@ -24,6 +24,7 @@
 # define EXIT 6
 # define LS 7
 # define GREP 8
+# define DQMARK 9
 
 # define READ 0
 # define WRITE 1
@@ -59,8 +60,9 @@ enum	e_flag
 
 
 int	g_flag[F_END];
+int g_status; // 이걸 256으로 나누면 exit status
 typedef struct	s_data {
-	unsigned char	exit_status;
+	// unsigned char	exit_status;
 	char **envp;
 }				t_data;
 

--- a/oh_my_minishell/signal.c
+++ b/oh_my_minishell/signal.c
@@ -9,9 +9,7 @@ void	catch_sigint(int pid)
 
 void	catch_sigquit(int pid)
 {
-	int		status;
-
-	pid = waitpid(-1, &status, WNOHANG);
+	pid = waitpid(-1, &g_status, WNOHANG);
 	if (!pid)
 		ft_putstr_fd("Quit: 3\n", 1);
 }


### PR DESCRIPTION
** 주요 목록 **
1. 명령어 ``$?``  기능을 추가했습니다.
2. 전역 변수 g_status 추가

** 변경된 파일 **
1. ``pipe.c``
부모 프로세스에서 각각 모든 자식 프로세스의 ``waitpid(pid, &g_status, 0)``명령어로 수정해서 종료상태를 계산할 수 있도록 수정했습니다.

그리고 프로세스가 아닌 빌트인 함수들도 ``echo``를 제외하고 추가하였습니다. ``echo``는 아직 완전히 구현이 되지 않아 무조건 일시적으로 ``g_status = 0``으로 설정해놨습니다.

이상한 명령어가 들어올 때 127번 ``exit status``를 낼 수 있도록 ``g_status = 127 * 256`` 으로 코드 추가했습니다.

2. ``signal.c``
시그널 함수에서 사용하는 status 변수를 종료 상태를 계산하여 저장하기 위해 전역 변수로 대체했습니다.

3. ``execute_pwd.c``, ``execute_exit.c``, ``execute_echo.c``
빌트인 함수 리턴 값의 상태에 따라 g_status을 올바르게 받아오도록 코드수정했습니다.

4. ``main.c``
g_status 초기화 코드 추가했습니다.

5. ``minishell.h``
전역 변수 추가, 예전에 사용하던 exit_status는 주석처리했습니다.

