### PR TITLE
gnl line convert to new line(with env, quotes, backslash)

### DIFF
--- a/oh_my_minishell/Makefile
+++ b/oh_my_minishell/Makefile
@@ -8,7 +8,8 @@ UTILS		= ./libft/ft_memset.c ./libft/ft_bzero.c  ./libft/ft_memcpy.c  ./libft/ft
 				 			./libft/ft_lstnew.c ./libft/ft_lstadd_front.c ./libft/ft_lstsize.c ./libft/ft_lstlast.c ./libft/ft_lstadd_back.c ./libft/ft_lstdelone.c ./libft/ft_lstclear.c ./libft/ft_lstiter.c ./libft/ft_lstmap.c\
 								./gnl/get_next_line.c ./gnl/get_next_line_utils.c
 SRCS		= main.c execute_commands.c get_commands_from_gnl.c print.c execute_echo.c execute_pwd.c execute_exit.c utils_jikang.c \
-				pipe.c signal.c init.c vector.c execute_env.c execute_unset.c execute_export.c execute_cd.c
+				pipe.c signal.c init.c vector.c execute_env.c execute_unset.c execute_export.c execute_cd.c \
+				refine_line_a.c refine_line_b.c refine_line_c.c
 OBJS		= $(SRCS:.c=.o)
 OBJS_UTILS	= $(UTILS:.c=.o)
 CC			= gcc

--- a/oh_my_minishell/execute_cd.c
+++ b/oh_my_minishell/execute_cd.c
@@ -23,7 +23,10 @@ static void	change_dir(char *path, char *envp[])
 
 	tmp = ft_strdup(path);
 	if (chdir(path) == -1)
+	{
 		ft_putendl_fd(strerror(errno), 2);
+		g_status = 1 * 256;
+	}
 	else
 	{
 		oldpwd = ft_strjoin("OLDPWD=", get_path(envp, "PWD"));
@@ -37,6 +40,7 @@ static void	change_dir(char *path, char *envp[])
 		free(tmp);
 		free(pwd);
 		free(oldpwd);
+		g_status = 0;
 	}
 }
 

--- a/oh_my_minishell/execute_echo.c
+++ b/oh_my_minishell/execute_echo.c
@@ -3,98 +3,29 @@
 void execute_echo(char *one_cmd_trimed)
 {
 	int i;
-	/* echo <--는 건너띄고 index 5번 부터 검사시작 */
-	i = 5;
-	/* echo 하고 띄어쓰기는 무시하고 넘어가기(is_whitespace) */
-	while (ft_is_whitespace(one_cmd_trimed[i]))
+	int flag_n;
+
+	flag_n = 0;
+	i = 4;
+	while (one_cmd_trimed[i] == ' ')
 		i++;
-	/* 이제 진짜 출력할 문자열 온 거임 "hi hi hi"*/
-	while (one_cmd_trimed[i] != '\0')
+	if (one_cmd_trimed[i] == '-')
 	{
-		/* 작은 따온표를 만나면 다시 작은 따온표를 만날 때 까지 */
-		/* 작은 따온표는 강한 문자열의 표시이므로 환경변수나 백슬래쉬로 문자변환 안된다 */
-		/* 그래서 우선순위의 최상단에 있기에 독립적인 if 문으로 올렸음 */
-		if (one_cmd_trimed[i] == '\'')
+		if (one_cmd_trimed[i + 1] == 'n')
 		{
-			i++;
-			if (one_cmd_trimed[i] == '\0')
-			{
-				ft_putstr_fd("\nerror! : 따온표 에러\n", 1);
-				break ;
-			}
-			while (one_cmd_trimed[i] != '\'' && one_cmd_trimed[i] != '\0')
-			{
-				ft_putchar_fd(one_cmd_trimed[i], 1);
+			i = i + 2;
+			flag_n = 1;
+			while (one_cmd_trimed[i] == ' ')
 				i++;
-			}
-			i++;
-		}
-		else
-		{
-			/* 큰 따온표를 만나면 다시 큰 따온표를 만날 때 까지 */
-			if (one_cmd_trimed[i] == '"')
-			{
-				/* 첫 따온표 스킵 */
-				i++;
-				while (one_cmd_trimed[i] != '"' && one_cmd_trimed[i] != '\0')
-				{
-					if (one_cmd_trimed[i] == '\\')
-					{
-						i++;
-						if (one_cmd_trimed[i] == '\\')
-						{
-							ft_putchar_fd('\\', 1);
-							i++;
-						}
-						else if (one_cmd_trimed[i] == '\'')
-						{
-							ft_putchar_fd('\'', 1);
-							i++;
-						}
-						else if (one_cmd_trimed[i] == '\"')
-						{
-							ft_putchar_fd('\"', 1);
-							i++;
-						}
-					}
-					else
-					{
-						ft_putchar_fd(one_cmd_trimed[i], 1);
-						i++;
-					}
-				}
-				i++;
-			}
-			else
-			{
-				if (one_cmd_trimed[i] == '\\')
-				{
-					i++;
-					if (one_cmd_trimed[i] == '\\')
-					{
-						ft_putchar_fd('\\', 1);
-						i++;
-					}
-					else if (one_cmd_trimed[i] == '\'')
-					{
-						ft_putchar_fd('\'', 1);
-						i++;
-					}
-					else if (one_cmd_trimed[i] == '\"')
-					{
-						ft_putchar_fd('\"', 1);
-						i++;
-					}
-				}
-				else
-				{
-					ft_putchar_fd(one_cmd_trimed[i], 1);
-					i++;
-				}
-			}
 		}
 	}
+	while (one_cmd_trimed[i] != '\0')
+	{
+		ft_putchar_fd(one_cmd_trimed[i], 1);
+		i++;
+	}
 	/* -n 옵션 들어갈 시 무시 */
-	ft_putchar_fd('\n', 1);
+	if (flag_n != 1)
+		ft_putchar_fd('\n', 1);
 	g_status = 0;
 }

--- a/oh_my_minishell/get_commands_from_gnl.c
+++ b/oh_my_minishell/get_commands_from_gnl.c
@@ -52,12 +52,14 @@ char		*ft_strsep(char **command, const char *delim)
 
 void get_commands_from_gnl(t_list **cmd, char *line)
 {
+	char *refined_line;
 	char *substr;
 	t_list *new;
 
+	refined_line = refine_line(line);
 	while (TRUE)
 	{
-		substr = ft_strsep(&line, ";");
+		substr = ft_strsep(&refined_line, ";");
 		if (substr == NULL)
 			break ;
 		if (ft_strlen(substr) == 0)

--- a/oh_my_minishell/main.c
+++ b/oh_my_minishell/main.c
@@ -23,7 +23,6 @@ int main(int argc, char *argv[], char **envp)
 				exit(0);
 			g_flag[CTRL_D] = 1;
 		}
-
 		ft_memset(g_flag, 0, sizeof(int) * F_END);
 		get_commands_from_gnl(&cmds, line);
 		// print_cmd_list(cmds); // linked list에 들어가있는 값을 '확인차' 출력해봄

--- a/oh_my_minishell/minishell.h
+++ b/oh_my_minishell/minishell.h
@@ -33,6 +33,8 @@
 # define WRONLY 1
 # define RDWR 2
 
+# define BUFF_MAX 1000
+
 enum	e_quotes
 {
 	Q_E = -3,
@@ -61,6 +63,14 @@ enum	e_flag
 
 int	g_flag[F_END];
 int g_status; // 이걸 256으로 나누면 exit status
+
+typedef struct	s_var
+{
+	int	i;
+	int k;
+	int flag_bq; // 큰 따옴표
+}				t_var;
+
 typedef struct	s_data {
 	// unsigned char	exit_status;
 	char **envp;
@@ -93,6 +103,7 @@ void execute_exit(char **argv);
 //utils_jikang.c
 t_data	*get_param();
 int		ft_is_whitespace(char c);
+void	init_array(char *buff);
 
 //pipe.c
 int		execute_command_nopipe(char *one_cmd);
@@ -121,4 +132,13 @@ int		execute_env(const char *path, char *const argv[], char *const envp[]);
 int		execute_unset(const char *path, char *const argv[], char *const envp[]);
 int		execute_export(const char *path, char *const argv[], char *const envp[]);
 int		execute_cd(const char *path, char *const argv[], char *const envp[]);
+
+// refine_line_a.c
+char	*refine_line(char *line);
+
+// refine_line_b.c
+int		refining_factory(char *buff, char *line, t_var *v, char **envlist);
+
+// refine_line_c.c
+int		convert_env(char *buff, char *line, t_var *v, char **envlist);
 #endif

--- a/oh_my_minishell/pipe.c
+++ b/oh_my_minishell/pipe.c
@@ -95,16 +95,6 @@ int		execve_nopipe(int num_cmd, char **argv, char *one_cmd_trimed)
 	if (num_cmd == CD) //built-in 함수를 써야함
 	{
 		execute_cd(argv[0], argv, get_param()->envp); // g_status 변수 세팅은 함수 안에서 해줘야할것같음 (?)
-		// // printf("CD command\n");
-		// if (chdir(argv[1]) == -1) /* 실패 시 */
-		// {
-		// 	g_status = 1 * 256;
-		// 	ft_putstr_fd("bash : cd: ", 1);
-		// 	ft_putstr_fd(argv[1], 1);
-		// 	ft_putendl_fd(": No such file or directory", 1);
-		// }
-		// else /* 성공 시 */
-		// 	g_status = 0;
 	}
 	if (num_cmd == PWD)
 	{
@@ -156,7 +146,9 @@ int		execute_command_nopipe(char *one_cmd)
 
 	one_cmd_trimed = ft_strtrim(one_cmd, " ");
 	one_cmd_splited = ft_split(one_cmd_trimed, ' ');
-
+	// ft_putendl_fd("여기가 onecmdtrimed", 1);
+	// ft_putendl_fd(one_cmd_trimed, 1);
+	// ft_putendl_fd("----------------", 1);
 	if (-1 == (num_cmd = which_command(one_cmd_splited[0])))
 	{
 		printf("command not found: %s\n", one_cmd_splited[0]);

--- a/oh_my_minishell/refine_line_a.c
+++ b/oh_my_minishell/refine_line_a.c
@@ -1,0 +1,54 @@
+#include "minishell.h"
+
+static void init_value(char *buff, t_var *v)
+{
+	init_array(buff);
+	v->flag_bq = 0;
+	v->i = 0;
+	v->k = 0;
+}
+
+int small_quote(char *buff, char *line, t_var *v)
+{
+	(v->i)++;
+	/* 작은 따옴표에 있는 것들 모두 받았습니다 */
+	while (line[v->i] != '\'' && line[v->i] != '\0')
+	{
+		buff[v->k] = line[v->i];
+		(v->k)++;
+		(v->i)++;
+	}
+	/* 작은 따옴표가 없을 때 */
+	if (line[v->i] == '\0')
+	{
+		ft_putendl_fd("작은 따옴표 닫아주세요", 1);
+		g_status = 1 * 256;
+		return (1);
+	}
+	return (0);
+}
+
+char *refine_line(char *line)
+{
+	char buff[BUFF_MAX];
+	t_var v;
+	char **envlist;
+
+	envlist = get_param()->envp;
+	init_value(buff, &v);
+	while (line[v.i] != '\0')
+	{
+		if (line[v.i] == '\'' && v.flag_bq == 0)
+		{
+			if (small_quote(buff, line, &v) == 1)
+				return (ft_strdup("\0"));
+		}
+		else // 스페이스 같은 경우는 나중에 else의 else에서 그냥 받아들이는 형태로 하면 될 듯
+		{
+			if (refining_factory(buff, line, &v, envlist) == 1)
+				return (ft_strdup("\0"));
+		}
+		(v.i)++;
+	}
+	return (ft_strdup(buff));
+}

--- a/oh_my_minishell/refine_line_b.c
+++ b/oh_my_minishell/refine_line_b.c
@@ -1,0 +1,35 @@
+#include "minishell.h"
+
+void onoff_flag_bq(int *flag_bq)
+{
+	if (*flag_bq == 0)
+		*flag_bq = 1; /* 큰 따옴표 flag on */
+	else
+		*flag_bq = 0; /* 큰 따옴표 flag off */
+}
+
+void back_slash(char *buff, char *line, int *k, int *i)
+{
+	(*i)++;
+	buff[*k] = line[*i];
+	(*k)++;
+}
+
+int refining_factory(char *buff, char *line, t_var *v, char **envlist)
+{
+	if (line[v->i] == '"')
+		onoff_flag_bq(&v->flag_bq);
+	else if (line[v->i] == '$')
+	{
+		if (convert_env(buff, line, v, envlist) == 1)
+			return(1);
+	}
+	else if (line[v->i] == '\\')
+		back_slash(buff, line, &v->k, &v->i);
+	else
+	{
+		buff[v->k] = line[v->i];
+		(v->k)++;
+	}
+	return (0);
+}

--- a/oh_my_minishell/refine_line_c.c
+++ b/oh_my_minishell/refine_line_c.c
@@ -1,0 +1,92 @@
+#include "minishell.h"
+
+int check_env(char *temp, char **envlist)
+{
+	int i;
+	int j;
+	char *var;
+
+	i = 0;
+	while (envlist[i] != NULL)
+	{
+		/* 우리가 찾는 환경 변수와 일치하다면 buff 에 알맞은 그 값을 넣어 준다. */
+		if (ft_strncmp(envlist[i], temp, ft_strlen(temp) + 1) == '=')
+		{
+			var = strchr(envlist[i], '=');
+			var++; /* '=' 이후가 진짜이니 +1 해준다. */
+			j = 0;
+			while (*var != '\0')
+			{
+				temp[j] = *var;
+				var++;	j++;
+			}
+			return (0); // 0 이 정상적으로 찾음
+		}
+		i++;
+	}
+	return (1); // 1이 환경변수 찾지 못함.
+}
+
+int replace_env(char *temp, char **envlist)
+{
+	int i;
+	int j;
+
+	if (temp[0] == 0)
+	{
+		temp[0] = '$';
+		return(0);
+	}
+	if (ft_strncmp("?", temp, ft_strlen(temp) + 1) == 0)
+	{
+		temp[0] = '$';
+		temp[1] = '?';
+		return (0);
+	}
+	if (check_env(temp, envlist) == 0)
+		return (0);
+	return (1);
+}
+
+void take_buff(char *buff, char *temp, int *k)
+{
+	int j;
+
+	j = 0;
+	while (temp[j] != '\0')
+	{
+		buff[*k] = temp[j];
+		(*k)++;
+		j++;
+	}
+}
+
+int convert_env(char *buff, char *line, t_var *v, char **envlist)
+{
+	int j;
+	char temp[BUFF_MAX];
+
+	init_array(temp);
+	(v->i)++;
+	j = 0;
+	while (line[v->i] != ' ' && line[v->i] != '\0' && line[v->i] != '"' && line[v->i] != '\'' && line[v->i] != '$')
+	{
+		temp[j] = line[v->i];
+		(v->i)++;
+		j++;
+	}
+	if (line[v->i] == '\'' || line[v->i] == '$')
+		(v->i)--;
+	// ft_putendl_fd(temp, 1);
+	/* 이제 temp에 환경 변수와 비교할 문자열이 들어감. */
+	/* 환경변수 리스트 돌려서 똑같은 거 찾은 다음 바꿔치기 해줘야함. */
+	if (replace_env(temp, envlist) == 1)
+	{
+		ft_putendl_fd("환경변수 에러", 1);
+		g_status = 1 * 256;
+		return (1);
+	}
+	/* 이제 temp에 바뀐 변수 받아왔으니 buff 에 넣어주자 */
+	take_buff(buff, temp, &v->k);
+	return (0);
+}

--- a/oh_my_minishell/utils_jikang.c
+++ b/oh_my_minishell/utils_jikang.c
@@ -11,3 +11,14 @@ int	ft_is_whitespace(char c)
 	return (c == ' ' || c == '\t' || c == '\v' || c == '\f'
 			|| c == '\n' || c == '\r');
 }
+
+void init_array(char *buff)
+{
+	int n;
+
+	n = 0;
+	while (n < BUFF_MAX)
+	{
+		buff[n++] = 0;
+	}
+}


### PR DESCRIPTION
**1. 푸쉬 목적**
``main 문의 gnl`` -> ``get_commands_from_gnl`` 로 이어지는 표준입력 문자열인 line을 
Ykoh님이 설정해준 get_param()->envp 변수에 따라 ``$``로 오는 환경변수와 ``'``, ``"``가 적절하게 
변형되어 우리가 프로그램에 넘길 때 문제없도록 코드를 짰습니다.
이 기능을 처리해주는 함수를 line 을 정제해준다는 뜻으로 refine_line 이라고 함수이름을 정했습니다.

또한, execute_cd.c의 함수가 적절하게 g_status를 설정해주고 적절한 command error를 낼 수 있도록 부모 프로세스와 자식 프로세스에 코드를 약간 추가했습니다.(부모랑 자식 프로세스에서 g_status가 제대로 넘어간다는 가정하에 추가했습니다. 테스트 요구됨, 이상하게 제가 했을 때는 잘 됐던 것으로 기억하는 데 다시해보겠습니다.)

**2. 크게 바뀐 점**
첫 번째. 이제 환경변수에 따라서 명령어가 수정된 명령어들을 사용하게 될것입니다. $PWD는 자동적으로 현재 디렉토리로 바뀔 것고, 문자 그대로 $PWD 값을 넣으려면 '$PWD'를 입력해야할 것입니다.

두 번째. execute_echo.c의 함수의 코드가 훨씬 간단히 바뀌었고, subject 에 있는 -n 옵션을 지원합니다.

**3. 추가된 파일**
1. refine_line_a.c, refine_line_b.c, refine_line_c.c

**4. 변경된 파일**
1. utils_jikang.c : 이 파일에 배열을 초기화해주는 init_array함수를 넣었습니다.
2. minishell.h : refine_line 함수에 사용되는 인덱스 및 flag를 가지고 있는 구조체 t_var을 추가했습니다.