### PR TITLE
execute_is_dir_file 에서 문자열에 '/'가 있는 것을 빼먹음.

### DIFF
--- a/oh_my_minishell/execute_is_dir_file.c
+++ b/oh_my_minishell/execute_is_dir_file.c
@@ -48,7 +48,7 @@ int			execute_is_dir_file(const char *path, char *const argv[], char *const envp
 	struct stat sb;
 
 	/* /user/bin/env 하면 환경변수 리스트 출력된다. */
-	if (ft_strncmp(path, "/usr/bin/env", 12) == '\0')
+	if (ft_strncmp(path, "/usr/bin/env", 13) == '\0')
 	{
 		return(execute_env(path, argv, envp));
 	}

--- a/oh_my_minishell/execute_is_dir_file.c
+++ b/oh_my_minishell/execute_is_dir_file.c
@@ -48,7 +48,7 @@ int			execute_is_dir_file(const char *path, char *const argv[], char *const envp
 	struct stat sb;
 
 	/* /user/bin/env 하면 환경변수 리스트 출력된다. */
-	if (ft_strncmp(path, "usr/bin/env", 12) == '\0')
+	if (ft_strncmp(path, "/usr/bin/env", 12) == '\0')
 	{
 		return(execute_env(path, argv, envp));
 	}


### PR DESCRIPTION
``ft_strncmp(path, "/usr/bin/env", 13) == '\0'``
여기서 '/' 랑 12를 13으로 바꿨습니다.