### PR TITLE
export error 처리 추가

### DIFF
--- a/oh_my_minishell/execute_export.c
+++ b/oh_my_minishell/execute_export.c
@@ -109,7 +109,9 @@ int			execute_export(const char *path, char *const argv[], char *const envp[])
 			if (!is_valid(argv[i]))
 			{
 				g_status = 1;
-				tmp = argv[i++];
+				ft_putstr_fd("bash: export: `", 2);
+				ft_putstr_fd(argv[i++], 2);
+				ft_putendl_fd("': not a valid identifier", 2);
 				continue ;
 			}
 			if ((j = is_exist((char **)envp, argv[i])))
@@ -122,14 +124,8 @@ int			execute_export(const char *path, char *const argv[], char *const envp[])
 	else
 		print_envp((char **)envp);
 	get_param()->envp = (char **)envp;
-	if (g_status == 1)
-	{
-		ft_putstr_fd("bash: export: `", 2);
-		ft_putstr_fd(tmp, 2);
-		ft_putendl_fd("': not a valid identifier", 2);
-		return (0);
-	}
-	g_status = 0;
+	if (g_status != 1)
+		g_status = 0;
 	return (0);
 	(void)path;
 }

--- a/oh_my_minishell/execute_export.c
+++ b/oh_my_minishell/execute_export.c
@@ -99,7 +99,7 @@ int			execute_export(const char *path, char *const argv[], char *const envp[])
 {
 	int		i;
 	int		j;
-	char	*tmp;
+
 	argv++;
 	if (vector_size((char **)argv))
 	{

--- a/oh_my_minishell/execute_export.c
+++ b/oh_my_minishell/execute_export.c
@@ -1,5 +1,25 @@
 #include "minishell.h"
 
+static int	is_valid(char str[])
+{
+	int		i;
+	int		end;
+	char	*eq;
+
+	if ((eq = ft_strchr(str, '=')))
+		end = eq - str;
+	else
+		end = ft_strlen(str);
+	i = 0;
+	while (i < end)
+	{
+		if (!ft_isalnum(str[i]) && !(str[i] == '_'))
+			return (0);
+		i++;
+	}
+	return (1);
+}
+
 static void	print_envp(char **envp) // DQ붙여서 해야함
 {
 	char	**tmp;
@@ -79,13 +99,19 @@ int			execute_export(const char *path, char *const argv[], char *const envp[])
 {
 	int		i;
 	int		j;
-
-	argv++; // 첫번쨰꺼 pass
+	char	*tmp;
+	argv++;
 	if (vector_size((char **)argv))
 	{
 		i = 0;
 		while (argv[i])
 		{
+			if (!is_valid(argv[i]))
+			{
+				g_status = 1;
+				tmp = argv[i++];
+				continue ;
+			}
 			if ((j = is_exist((char **)envp, argv[i])))
 				change_value((char **)&envp[j], argv[i]);
 			else
@@ -96,6 +122,14 @@ int			execute_export(const char *path, char *const argv[], char *const envp[])
 	else
 		print_envp((char **)envp);
 	get_param()->envp = (char **)envp;
+	if (g_status == 1)
+	{
+		ft_putstr_fd("bash: export: `", 2);
+		ft_putstr_fd(tmp, 2);
+		ft_putendl_fd("': not a valid identifier", 2);
+		return (0);
+	}
+	g_status = 0;
 	return (0);
 	(void)path;
 }


### PR DESCRIPTION
export에서 현재까지 발견한 에러는 다음과 같음.

- 1 -> not a valid identifier
- 1 -> readonly export
- 2 -> invalid option

export 구현 범위가 option은 제외이고,readonly는 환경변수 넘어오지않느 것같아서(?확인필요),
exit status가 1이 되는 not a valid identifier만 추가함. (g_status 도 수정)

`export [NAME=VALUE]`
에서 NAME에 `A-Z`, `a-z`, `0-9`, `_`외의 문자가 들어가는 경우에는 에러메시지 출력

수정 결과
```bash
export a b c ! a=asdf ^ a=asdfzz
# bash: export: `!': not a valid identifier
# bash: export: `^': not a valid identifier
# 위의 에러 메시지를 출력하고 a=asdfzz, b, c 환경변수를 추가함
```

위의 코드로 안되는 경우
```bash
export #
# export 모든 목록이 출력됨 # 자체가 뭐가 예약되어있나봄 그냥 bash에 #만 치면 오류가 안남 그래서 처리안해주고 냅둠 
# echo # 하면 개행만 출력되는 것처럼 # 자체가 공백내지는 그와 유사하게 처리되는듯..? 

export $$
# 실제동작 ->bash: export: `17545': not a valid identifier
# 미  니 쉘 ->bash: export: `$$': not a valid identifier
# $$ 자체가 어떤 숫자로 예약되어있나봄 이건 우선 내비두었음 굳이 처리하자고하면 처리할순 있을 듯

export a$a
# 잘동작함 

export a$a=asdf
# 실제동작 -> $a가 어떤 환경변수라 했을때 a$a에 값이 제대로 들어가짐
# 미  니 쉘 -> 환경변수에러 환경변수 처리 단에서 걸러지는 듯

export a
export a=$a
# 실제동작 -> 빈문자열로 제대로 들어가짐
# 미  니 쉘 -> 환경변수에러 환경변수 처리 단에서 걸러지는 듯
```