### PR TITLE
unset error 처리함수 추가

### DIFF
--- a/oh_my_minishell/execute_unset.c
+++ b/oh_my_minishell/execute_unset.c
@@ -1,5 +1,16 @@
 #include "minishell.h"
 
+static int	is_valid(char str[])
+{
+	while (*str)
+	{
+		if (!ft_isalnum(*str) && !(*str == '_'))
+			return (0);
+		str++;
+	}
+	return (1);
+}
+
 int		execute_unset(const char *path, char *const argv[], char *const envp[])
 {
 	int		i;
@@ -7,12 +18,18 @@ int		execute_unset(const char *path, char *const argv[], char *const envp[])
 	int		ret;
 	char	*eq;
 
-	argv++; // ./a.out 다음부터 할라고 넣은거 
-
-	//argv에서 not a valid identifier 검출하는 함수 추가해야함 
+	argv++;
 	i = 0;
 	while (argv[i])
 	{
+		if (!is_valid(argv[i]))
+		{
+			g_status = 1;
+			ft_putstr_fd("bash: export: `", 2);
+			ft_putstr_fd(argv[i++], 2);
+			ft_putendl_fd("': not a valid identifier", 2);
+			continue ;
+		}
 		j = 0;
 		while (envp[j])
 		{
@@ -31,6 +48,8 @@ int		execute_unset(const char *path, char *const argv[], char *const envp[])
 		}
 		i++;
 	}
+	if (g_status != 1)
+		g_status = 0;
 	return (0);
 	(void)path;
 }


### PR DESCRIPTION
unset에서 현재까지 발견한 에러는 다음과 같음.

- 1 -> not a valid identifier
- 1 -> readonly unset
- 2 -> invalid option

unset 구현 범위가 option은 제외이고, readonly는 환경변수 넘어오지않는 것같아서(?확인필요),
exit status가 1이 되는 not a valid identifier만 추가함. (g_status 도 수정)

`unset [NAME]`
에서 NAME에 `A-Z`, `a-z`, `0-9`, `_`외의 문자가 들어가는 경우에는 에러메시지 출력

수정 결과
```bash
export a b c d e f
unset a b c ! a=asdf ^ a=asdfzz
# bash: unset: `!': not a valid identifier
# bash: unset: `a=asdf': not a valid identifier
# bash: unset: `^': not a valid identifier
# bash: unset: `a=asdfzz': not a valid identifier
# 위의 에러 메시지를 출력하고 a, b, c 는 unset
```

위의 코드로 안되는 경우
```bash
unset #
# export # 와 유사한 이유로 건드리지 않음
# 실제동작 -> 아무것도 출력되지 않음
# 미  니 쉘 ->bash: export: `#': not a valid identifier

unset $$
# 실제동작 ->unset: export: `17545': not a valid identifier
# 미  니 쉘 ->unset: export: `$$': not a valid identifier
# $$ 자체가 어떤 숫자로 예약되어있나봄 이건 우선 내비두었음 굳이 처리하자고하면 처리할순 있을 듯

unset a$a
# 잘동작함 
```