### PR TITLE
 /bin 절대경로로 실행했을 때 동작하도록 함

### DIFF
--- a/oh_my_minishell/check_command.c
+++ b/oh_my_minishell/check_command.c
@@ -83,22 +83,22 @@ static t_builtin	is_builtin(char command[])
 }
 
 // 커맨드가 빌트인인지 아닌지 확인해줌, argv[]는 cmd_splited
-void check_command(char *argv[], char *envp[])
+void check_command(char *cmd, char *argv[], char *envp[])
 {
 	t_builtin	f;
 	char		*path;
 
-	if ((f = is_builtin(argv[0])))
-		f(argv[0], argv, envp);
+	if ((f = is_builtin(cmd)))
+		f(cmd, argv, envp);
 	else
 	{
-		if ((path = is_command(argv[0], envp)))
+		if ((path = is_command(cmd, envp)))
 			is_execve(path, argv, envp);
 			// execve(path, argv, envp);
 		else
 		{
 			ft_putstr_fd("minishell: ", 1);
-			ft_putstr_fd(argv[0], 1);
+			ft_putstr_fd(cmd, 1);
 			ft_putendl_fd(": command not found", 1);
 			g_status = 127 * 256;
 		}

--- a/oh_my_minishell/execute_echo.c
+++ b/oh_my_minishell/execute_echo.c
@@ -7,8 +7,10 @@ int execute_echo(const char *path, char *const argv[], char *const envp[])
 	char *one_cmd_trimed;
 
 	one_cmd_trimed = get_param()->cmd_trimed;
-	flag_n = 0;
 	i = 4;
+	flag_n = 0;
+	if (ft_strncmp(one_cmd_trimed, "/bin/echo", 9) == 0)
+		i = 9;
 	while (one_cmd_trimed[i] == ' ')
 		i++;
 	if (one_cmd_trimed[i] == '-')

--- a/oh_my_minishell/is_execve.c
+++ b/oh_my_minishell/is_execve.c
@@ -4,6 +4,8 @@ int is_execve(char *path, char **cmd_splited, char *envp[])
 {
 	int num_cmd;
 	pid_t pid;
+	char *temp1 = cmd_splited[1];
+	char *temp2 = cmd_splited[2];
 	num_cmd = which_command(cmd_splited[0]);
 	if (num_cmd == LS)
 	{

--- a/oh_my_minishell/is_execve.c
+++ b/oh_my_minishell/is_execve.c
@@ -33,7 +33,20 @@ int is_execve(char *path, char **cmd_splited, char *envp[])
 			waitpid(pid, &g_status, 0);
 		}
 	}
-	if (num_cmd == CLEAR) // Grep을 단독으로 썼을 떄에 대해서는 따로 구별해야할 듯
+	if (num_cmd == CLEAR)
+	{
+		if (-1 == (pid = fork()))
+			return (-1);
+		if (pid == 0)
+		{
+			execve(path, cmd_splited, get_param()->envp);
+		}
+		else
+		{
+			waitpid(pid, &g_status, 0);
+		}
+	}
+	if (num_cmd == CAT)
 	{
 		if (-1 == (pid = fork()))
 			return (-1);

--- a/oh_my_minishell/minishell.h
+++ b/oh_my_minishell/minishell.h
@@ -191,7 +191,7 @@ int		execute_export(const char *path, char *const argv[], char *const envp[]);
 int		execute_cd(const char *path, char *const argv[], char *const envp[]);
 int		execute_dqmark(const char *path, char *const argv[], char *const envp[]);
 //check_command.c
-void check_command(char *argv[], char *envp[]);
+void check_command(char *cmd, char *argv[], char *envp[]);
 //is_execve.c
 int is_execve(char *path, char **cmd_split, char *envp[]);
 //redirection.c

--- a/oh_my_minishell/minishell.h
+++ b/oh_my_minishell/minishell.h
@@ -31,6 +31,7 @@
 # define LS 7
 # define GREP 8
 # define CLEAR 10
+# define CAT 11
 
 # define READ 0
 # define WRITE 1

--- a/oh_my_minishell/pipe.c
+++ b/oh_my_minishell/pipe.c
@@ -45,6 +45,10 @@ int		which_command(char *cmd)
 		return (CLEAR);
 	if (!ft_strncmp(string_tolower(cmd),"/usr/bin/clear",15))
 		return (CLEAR);
+	if (!ft_strncmp(string_tolower(cmd),"cat",10))
+		return (CAT);
+	if (!ft_strncmp(string_tolower(cmd),"/bin/cat",15))
+		return (CAT);
 	else
 		return (-1);
 }

--- a/oh_my_minishell/pipe.c
+++ b/oh_my_minishell/pipe.c
@@ -35,9 +35,15 @@ int		which_command(char *cmd)
 	// 	return (EXIT);
 	if (!ft_strncmp(string_tolower(cmd),"ls",10))
 		return (LS);
+	if (!ft_strncmp(string_tolower(cmd),"/bin/ls",10))
+		return (LS);
 	if (!ft_strncmp(string_tolower(cmd),"grep",10))
 		return (GREP);
+	if (!ft_strncmp(string_tolower(cmd),"/usr/bin/grep",15))
+		return (GREP);
 	if (!ft_strncmp(string_tolower(cmd),"clear",10))
+		return (CLEAR);
+	if (!ft_strncmp(string_tolower(cmd),"/usr/bin/clear",15))
 		return (CLEAR);
 	else
 		return (-1);
@@ -92,7 +98,7 @@ int		execute_command_nopipe(char *one_cmd)
 	}
 	if (get_param()->symbol_array[0] == 0)
 	{
-		check_command(get_param()->cmd_splited, get_param()->envp);
+		check_command(get_param()->cmd_splited[0], get_param()->cmd_splited, get_param()->envp);
 		return (1);
 	}
 	else
@@ -143,7 +149,7 @@ void	child_process(char **one_cmd_splited, int *fd)
 		execute_nopipe_redirect();
 		exit(0);
 	}
-	check_command(one_cmd_splited, get_param()->envp);
+	check_command(one_cmd_splited[0], one_cmd_splited, get_param()->envp);
 	exit(0);
 }
 

--- a/oh_my_minishell/redirection.c
+++ b/oh_my_minishell/redirection.c
@@ -206,7 +206,7 @@ int execute_nopipe_redirect()
 		}
 		i++;
 	}
-	check_command(get_param()->cmd_redirect[0], get_param()->envp);
+	check_command(get_param()->cmd_redirect[0][0], get_param()->cmd_redirect[0], get_param()->envp);
 	dup_initalize();
 	return (1);
 }


### PR DESCRIPTION
절대경로로 실행했을 떄 동작하도록 함.

크게 바뀌 점
1. `void check_command(char *argv[], char *envp[])` 에서 
`void check_command(char *cmd, char *argv[], char *envp[])` 로 바뀜.
내부적으로는 cmd = argv[0]; 이기 때문에 크게 달라진 것은 없지만, 절대경로로 실행시킬 때, argv[0] = "/bin/echo" 이런식이기 때문에, *find_process_name(char *path)로 "echo"를 가리키는 포인터를 반환하고 사용하기위해서, char *cmd를 추가하였다.
2. *find_process_name(char *path)에서의 반환값은 "/bin/echo"의 경우  "/echo"를 가리키도록 되어있는데 '/'는 필요가 없어서 포인터를 +1 하여 반환하게하여 "echo"를 반환하게 하였다.
3. 절대경로로 실행한경우에도 `execute_echo` 함수를 사용하는데, 아직 절대경로에 대한 고려가 없었다. 절대경로에서는 서 echo, i = 4 가 항상 성립하지 않기 때문에 이를 보정하는 코드를 넣었다. 확인바람 @PennyBlack2008 
4.  노션에도 올렸는데, echo에서 문제가 있음. echo "      dst sd" → "dst sd" 로 출력됨(1.14)  @PennyBlack2008
