### PR TITLE
cd error 처리 추가

### DIFF
--- a/oh_my_minishell/execute_cd.c
+++ b/oh_my_minishell/execute_cd.c
@@ -28,7 +28,7 @@ static void	change_dir(const char *path, char *envp[])
 		ft_putstr_fd(path, 2);
 		ft_putstr_fd(": ", 2);
 		ft_putendl_fd(strerror(errno), 2);
-		g_status = 1;
+		g_status = 1 * 256;
 		return ;
 	}
 	argv[0] = "export";
@@ -48,7 +48,7 @@ static int	msg_notset(char str[])
 	ft_putstr_fd("bash: cd: ", 2);
 	ft_putstr_fd(str, 2);
 	ft_putendl_fd(": not set", 2);
-	g_status = 1;
+	g_status = 1 * 256;
 	return (-1);
 }
 


### PR DESCRIPTION
* 발견한 에러
	* chdir 실패했을 때 -> 1 -> errno로 알아서 출력하도록 함
	* HOME OLDPWD PWD가 없을 때 -> 1 -> not set 메시지로 출력
	
* 폴더 이동 후 OLDPWD, PWD에 상대경로 입력하면 상대경로 그대로 저장해서 폴더 이동이 꼬이는 문제 수정함
* cd ~ 동작하도록 수정함
* cd - 류와 cd ~ 류는 실제 동작과 약간 차이(에러메시지 등) 있을 수 있는데 구현 범위 넘는 것같아서 그냥 내비뒀음
* 평가표 동작 확인