### PR TITLE
issue#29 해결 : 절대경로 및 상대경로로 실행파일(a.out)실행시키기 및 /bin/ls 실행시키기

### DIFF
--- a/oh_my_minishell/check_command.c
+++ b/oh_my_minishell/check_command.c
@@ -65,9 +65,15 @@ static t_builtin	is_builtin(char command[])
 		return NULL;
 	if (ft_strncmp(string_tolower(command), "echo", 5) == '\0')
 		return (execute_echo);
+	else if (ft_strncmp(string_tolower(command), "/bin/echo", 10) == '\0')
+		return (execute_echo);
 	else if (ft_strncmp(string_tolower(command), "cd", 3) == '\0')
 		return (execute_cd);
+	else if (ft_strncmp(string_tolower(command), "/usr/bin/cd", 15) == '\0')
+		return (execute_cd);
 	else if (ft_strncmp(string_tolower(command), "pwd", 4) == '\0')
+		return (execute_pwd);
+	else if (ft_strncmp(string_tolower(command), "/bin/pwd", 15) == '\0')
 		return (execute_pwd);
 	else if (ft_strncmp(string_tolower(command), "export", 7) == '\0')
 		return (execute_export);
@@ -75,12 +81,15 @@ static t_builtin	is_builtin(char command[])
 		return (execute_unset);
 	else if (ft_strncmp(string_tolower(command), "env", 4) == '\0')
 		return (execute_env);
+	else if (ft_strncmp(string_tolower(command), "/usr/bin/env", 15) == '\0')
+		return (execute_env);
 	else if (ft_strncmp(string_tolower(command), "exit", 5) == '\0')
 		return (execute_exit);
 	else if (ft_strncmp(string_tolower(command), "$?", 3) == '\0')
 		return (execute_dqmark);
-	else if (ft_strncmp(string_tolower(command), "/", 1) == 0) //<-- 어짜피 NUL 문자인데, 여기서는 딱 문자하나 비교해서 0
-		return (execute_is_dir_file);
+	// else if (ft_strncmp(string_tolower(command), "/", 1) == 0 ||
+	// 			ft_strncmp(string_tolower(command), ".", 1) == 0) //<-- 어짜피 NUL 문자인데, 여기서는 딱 문자하나 비교해서 0
+	// 	return (execute_is_dir_file);
 	return (NULL);
 }
 
@@ -89,7 +98,13 @@ void check_command(char *cmd, char *argv[], char *envp[])
 {
 	t_builtin	f;
 	char		*path;
-
+	
+	if (ft_strncmp(string_tolower(cmd), "/", 1) == 0 ||
+				ft_strncmp(string_tolower(cmd), ".", 1) == 0) //<-- 어짜피 NUL 문자인데, 여기서는 딱 문자하나 비교해서 0
+	{
+		execute_is_dir_file(cmd, argv, envp);
+		return ;
+	}
 	if ((f = is_builtin(cmd)))
 		f(cmd, argv, envp);
 	else

--- a/oh_my_minishell/execute_is_dir_file.c
+++ b/oh_my_minishell/execute_is_dir_file.c
@@ -69,8 +69,19 @@ int			execute_is_dir_file(const char *path, char *const argv[], char *const envp
 		// if (execute_process((char *)path) == -1)
 		if (S_ISDIR(sb.st_mode) == 0 && (sb.st_mode & S_IXUSR))
 		{
-			cmd = find_process_name((char *)path);
-			check_command(cmd, (char **)argv, (char **)envp);
+			pid_t pid;
+			pid = fork();
+			if (pid == 0) 
+			{
+				execve(path, argv, envp);
+			}
+			else
+			{
+				waitpid(pid, NULL, 0);
+			}
+			// cmd = find_process_name((char *)path);
+			// check_command(cmd, (char **)argv, (char **)envp);
+			
 			g_status = 1 * 256;
 			return (1);
 		}


### PR DESCRIPTION
상대경로 및 절대경로의 시작은  . or / 이라고 생각해서, cmd에 첫글자가 . or / 이면 `execute_is_dir_file(cmd, argv, envp);`함수로 실행가능한 파일인지 판단한 후에 , 실행가능하면 execve로 돌아가도록 했음.

issue#29 에서 적어놓은 예시는 모두 동작함.
다만,   ~/minishell/a.out 은 ~ 가 매크로인것 같은데 정의가 되지않아서 동작하지 않음