### PR TITLE
환경변수 네이밍 적용, is_dir에서 대문자도 출력가능, echo -n -n 가능 

### DIFF
--- a/oh_my_minishell/execute_echo.c
+++ b/oh_my_minishell/execute_echo.c
@@ -1,5 +1,23 @@
 #include "minishell.h"
 
+void skip_n_option(char *str, int *i, int *flag_n)
+{
+	int j;
+
+	j = *i;
+	while (str[j] && str[j + 1] && str[j + 2])
+	{
+		if (str[j] == '-' && str[j + 1] == 'n' && str[j + 2] == ' ')
+		{
+			j = j + 3;
+			*flag_n = 1;
+			*i = j;
+		}
+		else
+			break ;
+	}
+}
+
 int execute_echo(const char *path, char *const argv[], char *const envp[])
 {
 	int i;
@@ -13,16 +31,7 @@ int execute_echo(const char *path, char *const argv[], char *const envp[])
 		i = 9;
 	while (one_cmd_trimed[i] == ' ')
 		i++;
-	if (one_cmd_trimed[i] == '-')
-	{
-		if (one_cmd_trimed[i + 1] == 'n')
-		{
-			i = i + 2;
-			flag_n = 1;
-			while (one_cmd_trimed[i] == ' ')
-				i++;
-		}
-	}
+	skip_n_option(one_cmd_trimed, &i, &flag_n);
 	while (one_cmd_trimed[i] != '\0')
 	{
 		ft_putchar_fd(one_cmd_trimed[i], 1);

--- a/oh_my_minishell/execute_echo.c
+++ b/oh_my_minishell/execute_echo.c
@@ -16,6 +16,12 @@ void skip_n_option(char *str, int *i, int *flag_n)
 		else
 			break ;
 	}
+	if (str[j] == '-' && str[j + 1] == 'n' && str[j + 2] == '\0')
+	{
+		j = j + 2;
+		*flag_n = 1;
+		*i = j;
+	}
 }
 
 int execute_echo(const char *path, char *const argv[], char *const envp[])

--- a/oh_my_minishell/execute_is_dir_file.c
+++ b/oh_my_minishell/execute_is_dir_file.c
@@ -14,6 +14,7 @@ char		*find_process_name(char *path)
 		i++;
 	}
 	file_name = path + j + 1;
+	ft_putendl_fd(file_name, 1);
 	return (file_name);
 }
 
@@ -56,10 +57,8 @@ int			execute_is_dir_file(const char *path, char *const argv[], char *const envp
 	{
 		/* 여기들어오는 게 비정상상태(잘못된 경로)*/
 		ft_putstr_fd("minishell: ", 1);
-		ft_putendl_fd("no such file or directory :", 1);
-		ft_putstr_fd(path, 1);
-		ft_putchar_fd('\n', 1);
-		// ft_putnbr_fd(!stat(path, &sb), 1);
+		ft_putstr_fd(get_param()->cmd_trimed, 1);
+		ft_putendl_fd(": No such file or directory", 1);
 		g_status = 127 * 256;
 		return (0);
 	}
@@ -70,14 +69,15 @@ int			execute_is_dir_file(const char *path, char *const argv[], char *const envp
 		if (S_ISDIR(sb.st_mode) == 0 && (sb.st_mode & S_IXUSR))
 		{
 			cmd = find_process_name((char *)path);
-			check_command(cmd, (char **)argv, (char **)envp);
+			/* 여기서 check_command 에 없는 ls 가 들어가면 segfault 오류난다. */
+			check_command(cmd, (char **)path, (char **)envp);
 			g_status = 1 * 256;
 			return (1);
 		}
 		else
 		{
 			ft_putstr_fd("minishell: ", 1);
-			ft_putstr_fd(path, 1);
+			ft_putstr_fd(get_param()->cmd_trimed, 1);
 			if (S_ISDIR(sb.st_mode))
 			{
 				ft_putendl_fd(": is a directory", 1);

--- a/oh_my_minishell/pipe.c
+++ b/oh_my_minishell/pipe.c
@@ -3,7 +3,8 @@
 char *string_tolower(char *str)
 {
 	int i;
-
+	ft_putendl_fd("string_tolower에서 처리전 비교", 1);
+	ft_putendl_fd(str, 1);
 	if (str == NULL)
 		return (NULL);
 	i = 0;
@@ -12,6 +13,8 @@ char *string_tolower(char *str)
 		str[i] = ft_tolower(str[i]);
 		i++;
 	}
+	ft_putendl_fd("string_tolower에서 처리후, 비교", 1);
+	ft_putendl_fd(str, 1);
 	return (str);
 }
 

--- a/oh_my_minishell/pipe.c
+++ b/oh_my_minishell/pipe.c
@@ -3,8 +3,6 @@
 char *string_tolower(char *str)
 {
 	int i;
-	ft_putendl_fd("string_tolower에서 처리전 비교", 1);
-	ft_putendl_fd(str, 1);
 	if (str == NULL)
 		return (NULL);
 	i = 0;
@@ -13,8 +11,6 @@ char *string_tolower(char *str)
 		str[i] = ft_tolower(str[i]);
 		i++;
 	}
-	ft_putendl_fd("string_tolower에서 처리후, 비교", 1);
-	ft_putendl_fd(str, 1);
 	return (str);
 }
 

--- a/oh_my_minishell/refine_line_c.c
+++ b/oh_my_minishell/refine_line_c.c
@@ -1,5 +1,12 @@
 #include "minishell.h"
 
+static int is_env_ch(char c)
+{
+	if (ft_isalpha(c) || ft_isdigit(c) || c == '_')
+		return (1);
+	return (0);
+}
+
 int check_env(char *temp, char **envlist)
 {
 	int i;
@@ -69,7 +76,7 @@ int convert_env(char *buff, char *line, t_var *v, char **envlist)
 	init_array(temp);
 	(v->i)++;
 	j = 0;
-	while (line[v->i] != ' ' && line[v->i] != '\0' && line[v->i] != '"' && line[v->i] != '\'' && line[v->i] != '$' && line[v->i] != '/' && line[v->i] != '.')
+	while (is_env_ch(line[v->i]))
 	{
 		temp[j] = line[v->i];
 		(v->i)++;


### PR DESCRIPTION
관련 예제 코드: https://www.notion.so/1-14-jikang-9697185d3b4a4facba98beab1d8a9512
1.  환경 변수 네이밍 적용 (is_alnum, underscore('_'))
2. is_dir_file에서 함수 string_tolower 의 영향으로 path를 출력하여 대문자 출력이 안되었는데, get_param()->cmd_trimed로 바꾸어 대문자도 출력이 되게함.
3. echo -n -n -n -n 이 출력가능하도록 만들었습니다.
