### PR TITLE
1.14 21시

### DIFF
--- a/oh_my_minishell/check_command.c
+++ b/oh_my_minishell/check_command.c
@@ -99,6 +99,8 @@ void check_command(char *cmd, char *argv[], char *envp[])
 	t_builtin	f;
 	char		*path;
 	
+	if (cmd == NULL)
+		return;
 	if (ft_strncmp(string_tolower(cmd), "/", 1) == 0 ||
 				ft_strncmp(string_tolower(cmd), ".", 1) == 0) //<-- 어짜피 NUL 문자인데, 여기서는 딱 문자하나 비교해서 0
 	{

--- a/oh_my_minishell/ft_strsemi.c
+++ b/oh_my_minishell/ft_strsemi.c
@@ -26,9 +26,10 @@ char *ft_strsemi(char **str_pointer, int *array, int i)
 		else
 		{
 			temp = array[i] - array[i -1] - 1;
-			(*str_pointer)[array[temp]] = 0;
+			(*str_pointer)[temp] = 0;
 			(*str_pointer) += (temp + 1);
 			return (ret);
 		}
 	}
 }
+//  echo 222;

--- a/oh_my_minishell/get_commands_from_gnl.c
+++ b/oh_my_minishell/get_commands_from_gnl.c
@@ -56,20 +56,21 @@ void get_commands_from_gnl(t_list **cmd, char *line)
 	char *refined_line;
 	char *temp;
 	t_list *new;
-	int i;
+	int j;
 	refined_line = refine_line(line);
 	temp = refined_line;
-	i = 0;
-	// while (i < BUFF_MAX)
-	// {
-	// 	if (get_param()->semi_arr[i] == 0)
-	// 	{
-	// 		printf("이제 없음\n");
-	// 		break ;
-	// 	}
-	// 	printf("semi_arr[%d] : %d\n", i, get_param()->semi_arr[i]);
-	// 	i++;
-	// }
+	j = 0;
+	while (j < BUFF_MAX)
+	{
+		if (get_param()->semi_arr[j] == 0)
+		{
+			printf("이제 없음\n");
+			break ;
+		}
+		printf("semi_arr[%d] : %d\n", j, get_param()->semi_arr[j]);
+		j++;
+	}
+	int i = 0;
 	while (TRUE)
 	{
 		// substr = ft_strsep(&refined_line, ";");
@@ -85,3 +86,5 @@ void get_commands_from_gnl(t_list **cmd, char *line)
 	}
 	free(temp);
 }
+
+// echo 111; echo 222; echo 333


### PR DESCRIPTION
1. ' ^D' 입력시에 segfault error 잡아줌.
(대부분 세그폴트는 ft_strncmp에서 자주 난다)
2. ft_strdiv 코드 수정.
세미콜론이 3개이상에서는 정상작동하지 않았는데, 사소한 코드 실수여서 고쳤음