### PR TITLE
Fix : "_=" print bottom in ENV and nonprint in EXPORT (#38)

### DIFF
--- a/oh_my_minishell/execute_env.c
+++ b/oh_my_minishell/execute_env.c
@@ -1,19 +1,42 @@
 #include "minishell.h"
 
-//		export 에서 value를 할당하지 않은 변수들은 출력하지 않음
-//		출력되는 순서는 어떤 규칙인지 아직 발견하지 못함
+static void	export_env_path(const char *path, char *const argv[], char *const envp[])
+{
+	char	*tmp[3];
+
+	tmp[0] = "export";
+	if (ft_strncmp(path, "env", 4) == '\0')
+		tmp[1] = ft_strjoin("_=", "/usr/bin/env");
+	else
+		tmp[1] = ft_strjoin("_=", path);
+	tmp[2] = NULL;
+	execute_export(path, tmp, envp);
+	free(tmp[1]);
+}
+
 int		execute_env(const char *path, char *const argv[], char *const envp[])
 {
-	int	i;
-	
+	int		i;
+	int		j;
+	char	**tmp;
+
+	export_env_path(path, argv, get_param()->envp);
 	i = 0;
 	while (envp[i])
 	{
 		if (ft_strchr(envp[i], '='))
+		{
+			if (ft_strncmp(envp[i], "_=", 2) == '\0')
+			{
+				j = i++;
+				continue;
+			}
 			ft_putendl_fd(envp[i], 1);
+		}
 		i++;
 	}
+	ft_putendl_fd(envp[j], 1);
+	g_status = 0;
 	return (0);
-	(void)path;
 	(void)argv;
 }

--- a/oh_my_minishell/execute_export.c
+++ b/oh_my_minishell/execute_export.c
@@ -31,6 +31,11 @@ static void	print_envp(char **envp) // DQ붙여서 해야함
 	i = 0;
 	while (tmp[i])
 	{
+		if (ft_strncmp(tmp[i], "_=", 2) == '\0')
+		{
+			i++;
+			continue ;
+		}
 		ft_putstr_fd("declare -x ", 1);
 		if ((eq = ft_strchr(tmp[i], '=')))
 		{


### PR DESCRIPTION
#38 이슈에 대한 `fix`임

* `env`를 출력하면 `_=/usr/bin/env`하고 env 바이너리 이름 나오는 부분 적절하게 표시되게 수정
`/usr/bin/./././././env` 이런거 해도 `_=/usr/bin/./././././env` 로 제대로 나옴

* `_=`가 제일 아래에 표시되게 수정 전에는 export 해서 추가한 것들이 있으면 그위에 출력 되었는데 export가 있더라도 제일 아래 출력되게 수정
나머지 것들은 순서 보장 못함(규칙을 알수없음)

* `export` 에서는 `_=`가 안나오게 수정
* 단순 `env`는 에러가 날 수 없다고 가정하여 에러처리 없이 무조건 `g_status = 0`으로 고정되게 함 