### PR TITLE
Yunslee

### DIFF
--- a/oh_my_minishell/execute_commands.c
+++ b/oh_my_minishell/execute_commands.c
@@ -4,8 +4,11 @@ static void error_except()
 {
 	if (g_except[SYNTAX] != 0)
 	{
-		ft_putstr_fd("minishell: parse error near '", 1);
-		ft_putchar_fd(g_except[SYNTAX], 1);
+		ft_putstr_fd("minishell: syntax error near unexpected token '", 1);
+		if (g_except[SYNTAX] == 10)
+			ft_putstr_fd("newline", 1);
+		else
+			ft_putchar_fd(g_except[SYNTAX], 1);
 		ft_putstr_fd("'\n", 1);
 	}
 	g_except[SYNTAX] = 0;
@@ -21,6 +24,21 @@ int execute_command(char **split_by_pipes)
 		g_except[SYNTAX] = '|';
 		return (-1);
 	}
+	if (ft_strncmp(split_by_pipes[0], ";", 1) == 0)
+	{
+		g_except[SYNTAX] = ';';
+		return (-1);
+	}
+	if (ft_strncmp(split_by_pipes[0], "<", 1) == 0)
+	{
+		g_except[SYNTAX] = 10;
+		return (-1);
+	}
+	if (ft_strncmp(split_by_pipes[0], ">", 1) == 0)
+	{
+		g_except[SYNTAX] = 10;
+		return (-1);
+	}	
 	if (split_by_pipes[1] == NULL)
 	{
 		if (-1 == (execute_command_nopipe(split_by_pipes[0])))
@@ -46,7 +64,7 @@ int execute_multi_commands(t_list *cmds)
 	{
 		if (-1 == execute_command(cur->split_by_pipes))
 		{
-			printf("execute_command error\n");
+			// printf("execute_command error\n");
 			error_except();
 		}
 		cmd_exit();

--- a/oh_my_minishell/execute_env.c
+++ b/oh_my_minishell/execute_env.c
@@ -6,6 +6,14 @@ int		execute_env(const char *path, char *const argv[], char *const envp[])
 {
 	int	i;
 	
+	if (argv[1] != NULL)
+	{
+		g_status = 256 * 127;
+		ft_putstr_fd("env: ", 1);
+		ft_putstr_fd(argv[1], 1);
+		ft_putendl_fd(": No such file or directory", 1);
+		return (-1);
+	}
 	i = 0;
 	while (envp[i])
 	{

--- a/oh_my_minishell/execute_exit.c
+++ b/oh_my_minishell/execute_exit.c
@@ -6,7 +6,7 @@
 /*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/04 21:30:41 by jikang            #+#    #+#             */
-/*   Updated: 2021/01/09 03:30:43 by yunslee          ###   ########.fr       */
+/*   Updated: 2021/01/16 00:33:08 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -87,6 +87,7 @@ int execute_exit(const char *path, char *const argv[], char *const envp[])
 	if (i == 1)
 	{
 		// printf("i: %i\n", i);
+		ft_putendl_fd("exit", 1);
 		exit(g_status);
 	}
 	/* i = 2 일 경우, 명령어 제대로 들어옴 */
@@ -95,6 +96,7 @@ int execute_exit(const char *path, char *const argv[], char *const envp[])
 	{
 		// printf("i: %i\n", i);
 		// printf("cmd_splited[1]: %s\n", cmd_splited[1]);
+		ft_putendl_fd("exit", 1);
 		one_argv(cmd_splited[1]);
 	}
 	else
@@ -102,6 +104,7 @@ int execute_exit(const char *path, char *const argv[], char *const envp[])
 		// printf("i: %i\n", i);
 		// printf("cmd_splited[1]: %s\n", cmd_splited[1]);
 		// printf("cmd_splited[2]: %s\n", cmd_splited[2]);
+		ft_putendl_fd("exit", 1);
 		more_than_one_argv(cmd_splited[1]);
 	}
 	return (1);

--- a/oh_my_minishell/main.c
+++ b/oh_my_minishell/main.c
@@ -18,7 +18,10 @@ int main(int argc, char *argv[], char **envp)
 		while (!(get_next_line(0, &line)))
 		{
 			if (!g_flag[CTRL_D] && !line[0])
+			{
+				ft_putendl_fd("exit", 1);
 				exit(0);
+			}
 			g_flag[CTRL_D] = 1;
 		}
 		ft_memset(g_flag, 0, sizeof(int) * F_END);


### PR DESCRIPTION
1. issue #37 
; | < > 하나만 쳐졌을 때, 에러메세지를 출력하도록 함. 매우 부분적인 해결..
`    ;` `     | `   `    <` 이런 경우 메세지를 출력하지않고, 그냥 실행되지도 않으며 넘어감
2. issue #40 
`^D` 와 `exit` 했을 때, exit을 출력하도록 함.
3. issue #44 의 4번째 env의 에러처리에 대해서 상충하는 부분이 있음. 