### PR TITLE
fixed redirection and backslash in quote

### DIFF
--- a/oh_my_minishell/check_command.c
+++ b/oh_my_minishell/check_command.c
@@ -87,9 +87,6 @@ static t_builtin	is_builtin(char command[])
 		return (execute_exit);
 	else if (ft_strncmp(string_tolower(command), "$", 1) == 0)
 		return (execute_dqmark);
-	// else if (ft_strncmp(string_tolower(command), "/", 1) == 0 ||
-	// 			ft_strncmp(string_tolower(command), ".", 1) == 0) //<-- 어짜피 NUL 문자인데, 여기서는 딱 문자하나 비교해서 0
-	// 	return (execute_is_dir_file);
 	return (NULL);
 }
 
@@ -113,7 +110,6 @@ void check_command(char *cmd, char *argv[], char *envp[])
 	{
 		if ((path = is_command(cmd, envp)))
 			is_execve(path, argv, envp);
-			// execve(path, argv, envp);
 		else
 		{
 			ft_putstr_fd("minishell: ", 1);

--- a/oh_my_minishell/execute_cd.c
+++ b/oh_my_minishell/execute_cd.c
@@ -36,7 +36,7 @@ static void	change_dir(const char *path, char *envp[])
 	argv[1] = ft_strjoin("OLDPWD=", pwd);
 	execute_export(argv[0], argv, get_param()->envp);
 	free(argv[1]);
-	getcwd(pwd, PATH_MAX + 1);	
+	getcwd(pwd, PATH_MAX + 1);
 	argv[1] = ft_strjoin("PWD=", pwd);
 	execute_export(argv[0], argv, get_param()->envp);
 	free(argv[1]);

--- a/oh_my_minishell/execute_echo.c
+++ b/oh_my_minishell/execute_echo.c
@@ -32,6 +32,7 @@ int execute_echo(const char *path, char *const argv[], char *const envp[])
 	char *echo_line;
 
 	one_cmd_trimed = get_param()->cmd_trimed;
+	// ft_putendl_fd(one_cmd_trimed, 1);
 	i = 4;
 	flag_n = 0;
 	if (ft_strncmp(one_cmd_trimed, "/bin/echo", 9) == 0)

--- a/oh_my_minishell/refine_line_b.c
+++ b/oh_my_minishell/refine_line_b.c
@@ -3,16 +3,37 @@
 void onoff_flag_bq(int *flag_bq)
 {
 	if (*flag_bq == 0)
-		*flag_bq = 1; /* 큰 따옴표 flag on */
+		*flag_bq = 1; /* 큰 따옴표 flag on : 큰 따옴표 안에 있음 */
 	else
-		*flag_bq = 0; /* 큰 따옴표 flag off */
+		*flag_bq = 0; /* 큰 따옴표 flag off : 큰 따옴표 밖에 있음 */
 }
 
-void back_slash(char *buff, char *line, int *k, int *i)
+void back_slash(char *buff, char *line, t_var *v)
 {
-	(*i)++;
-	buff[*k] = line[*i];
-	(*k)++;
+	if (v->flag_bq == 0)
+		(v->i)++;
+	buff[v->k] = line[v->i];
+	(v->k)++;
+}
+
+int is_redirect(char *buff, char *line, t_var *v)
+{
+	/* 아예 line을 NUL까지 밀어버리자 */
+	if (line[v->i] == '>' && v->flag_bq == 0)
+	{
+		while (line[v->i] != '\0')
+			(v->i)++;
+		(v->i)--;
+		return (1);
+	}
+	else if (line[v->i] == '<' && v->flag_bq == 0)
+	{
+		while (line[v->i] != '\0')
+			(v->i)++;
+		(v->i)--;
+		return (1);
+	}
+	return (0);
 }
 
 int refining_factory(char *buff, char *line, t_var *v, char **envlist)
@@ -25,9 +46,11 @@ int refining_factory(char *buff, char *line, t_var *v, char **envlist)
 			return(1);
 	}
 	else if (line[v->i] == '\\')
-		back_slash(buff, line, &v->k, &v->i);
+		back_slash(buff, line, v);
 	else
 	{
+		if (is_redirect(buff, line, v) == 1)
+			return (0);
 		buff[v->k] = line[v->i];
 		(v->k)++;
 	}


### PR DESCRIPTION
1. 큰 따옴표 밖에 리디렉션이 있을 때 echo 는 리디렉션 전까지 읽습니다.

2.`echo "sfds\n"` 을 했을 때, 백슬레쉬가 나오지 않는 문제를  해결했습니다.