### PR TITLE
now echo "|" is working

### DIFF
--- a/oh_my_minishell/get_commands_from_gnl.c
+++ b/oh_my_minishell/get_commands_from_gnl.c
@@ -106,6 +106,76 @@ void unseal_firstquotes(char **splited)
 	}
 }
 
+char **split_str_by_pipe(char *str, int *buff, t_var *v)
+{
+	char **new;
+	int pipe_num;
+	int m, n;	m = 0;	n = 0;
+
+	pipe_num = v->k;
+	new = (char **)malloc(sizeof(char *) * (pipe_num + 2));
+	if (pipe_num == 0)
+	{
+		new[0] = ft_strdup(str);
+		new[1] = NULL;
+		return (new);
+	}
+	/* buff 에서 인덱스를 받아와서 거기 까지만 해준다 */
+	while (m <= pipe_num)
+	{
+		if (m == 0)
+		{
+			new[m] = ft_strdup_by_index(str, 0, buff[m] - 1);
+		}
+		else
+		{
+			/* 문자열 복붙해주지만, 인덱스를 받아 시작과 끝을 복붙해주는 */
+			if (buff[m] == 0)
+				buff[m] = ft_strlen(str) + 1;
+			new[m] = ft_strdup_by_index(str, buff[m - 1] + 1, buff[m] - 1);
+		}
+		m++;
+	}
+	new[m] = NULL;
+	return (new);
+}
+
+char **split_pipe(char *substr)
+{
+	t_var v;
+	v.flag_bq = 0;
+	v.flag_sq = 0;
+	int flag_pipe = 0; // 중복되는 파이프 피하기 위해서
+	char **str_arr;
+	int buff[BUFF_MAX];
+	init_array_int(buff);
+	v.i = 0; v.l = 0; v.k = 0;
+	while (substr[v.i] != '\0')
+	{
+		if (substr[v.i] == '|')
+		{
+			/* 따옴표 안에 없는 파이프의 위치값을 buff 에 저장 */
+			if (v.flag_bq == 0 && v.flag_sq == 0 && flag_pipe == 0)
+			{
+				buff[(v.k)++] = v.i;
+				flag_pipe = 1;
+			}
+		}
+		else
+		{
+			if (substr[v.i] == '"')
+				change_flag(&v.flag_bq);
+			else if (substr[v.i] == '\'')
+				change_flag(&v.flag_sq);
+			flag_pipe = 0;
+		}
+		(v.i)++;
+	}
+	/* 이제 buff 에 담긴 파이프에 따라서 str_arr에 잘라서 넣어주자 */
+	str_arr = split_str_by_pipe(substr, buff, &v);
+	return (str_arr);
+}
+
 void get_commands_from_gnl(t_list **cmd, char *line)
 {
 	char *substr;
@@ -123,7 +193,8 @@ void get_commands_from_gnl(t_list **cmd, char *line)
 		if (ft_strlen(substr) == 0)
 			continue ;
 		new = ft_lstnew(substr);
-		new->split_by_pipes = ft_split(substr, '|');
+		// new->split_by_pipes = ft_split(substr, '|');
+		new->split_by_pipes = split_pipe(substr);
 		/* 여기서 new->split_by_pipes 가 따옴표로 시작하면 한꺼풀 걷어주자 */
 		unseal_firstquotes(new->split_by_pipes);
 		print_split(new->split_by_pipes);

--- a/oh_my_minishell/minishell.h
+++ b/oh_my_minishell/minishell.h
@@ -108,6 +108,7 @@ typedef struct	s_var
 	int k;
 	int l;
 	int flag_bq; // 큰 따옴표
+	int flag_sq; // 작은 따옴표
 }				t_var;
 
 
@@ -160,7 +161,7 @@ void	init_array(char *buff);
 void	init_array_int(int *buff);
 void	check_semicolon(char *str);
 void	change_flag(int *flag);
-void	onoff_flag(int *flag);
+char *ft_strdup_by_index(char *str, int start, int end);
 
 //pipe.c
 int		execute_command_nopipe(char *one_cmd);

--- a/oh_my_minishell/utils_jikang.c
+++ b/oh_my_minishell/utils_jikang.c
@@ -74,3 +74,24 @@ void check_semicolon(char *str)
 		i++;
 	}
 }
+
+char *ft_strdup_by_index(char *str, int start, int end)
+{
+	char *new;
+	int i;
+	int j;
+
+	if (str == NULL || start < 0 || start > end || ft_strlen(str) < end)
+		return (0);
+	if (start == end)
+		ft_strdup(" ");
+	new = malloc(sizeof(char) * (end - start + 2));
+	i = start;	j = 0;
+	while (i <= end)
+	{
+		new[j] = str[i];
+		i++;	j++;
+	}
+	new[j] = '\0';
+	return (new);
+}


### PR DESCRIPTION
`echo "|"` 이제 됩니다. leak 확인

ls | grep a 도 되고, 정상적인 파이프는 다 되는데,

`ls |||||| ls` 는 정상적인 에러 메시지를 도출하지 않습니다. 그리고 double pipe 실행을 고려하지 않았습니다.

놂맞추기 힘들 듯..