### PR TITLE
Yunslee 1.19

### DIFF
--- a/oh_my_minishell/main.c
+++ b/oh_my_minishell/main.c
@@ -1,10 +1,28 @@
 #include "minishell.h"
 #include <stdio.h>
 
+static void ft_addchr(char **s, char c)
+{
+	char	*ret;
+	int		count;
+
+	if (*s)
+		count = strlen(*s) + 2;
+	else
+		count = 2;
+	ret = calloc(count, sizeof(char));
+	if (*s)
+		strlcpy(ret, *s, count);
+	ret[count - 2] = c;
+	free(*s);
+	*s = ret;
+}
+
 int main(int argc, char *argv[], char **envp)
 {
 	t_list *cmds = NULL;
 	char *line;
+	char c;
 
 	minishell_init(argc, argv, envp); // <-- semi_arr 가 초기화
 	catch_signals();
@@ -15,25 +33,16 @@ int main(int argc, char *argv[], char **envp)
 			g_flag[CTRL_BS] = 0;
 		else
 			ft_putstr_fd("minishell$ ",1);
-		// while (read(0, &c, 1) !=0 && c != '\n' )
-		// {
-		// 	// printf("value:%c\n", c);
-		// 	ft_addchr(&line, c);
-		// 	if (!g_flag[CTRL_D] && !line[0])
-		// 	{
-		// 		ft_putendl_fd("exit", 1);
-		// 		exit(0);
-		// 	}
-		// 	g_flag[CTRL_D] = 1;
-		// }
-		while (!(get_next_line(0, &line)))
+		while (read(0, &c, 1))
 		{
-			if (!line[0])
+			if (c == '\n')
+				break;
+			else if (c == '\0')
 			{
 				ft_putendl_fd("exit", 1);
-				exit(0);
+				minishell_exit(cmds); exit(0);
 			}
-			// g_flag[CTRL_D] = 1;
+			ft_addchr(&line, c);
 		}
 		ft_memset(g_flag, 0, sizeof(int) * F_END);
 		get_commands_from_gnl(&cmds, line);

--- a/oh_my_minishell/main.c
+++ b/oh_my_minishell/main.c
@@ -33,16 +33,14 @@ int main(int argc, char *argv[], char **envp)
 			g_flag[CTRL_BS] = 0;
 		else
 			ft_putstr_fd("minishell$ ",1);
-		while (read(0, &c, 1))
+		while (read(0, &c, 1) && c != '\n')
 		{
-			if (c == '\n')
-				break;
-			else if (c == '\0')
-			{
-				ft_putendl_fd("exit", 1);
-				minishell_exit(cmds); exit(0);
-			}
 			ft_addchr(&line, c);
+		}
+		if (c == '\0')
+		{
+			ft_putendl_fd("exit", 1);
+			minishell_exit(cmds); exit(0);
 		}
 		ft_memset(g_flag, 0, sizeof(int) * F_END);
 		get_commands_from_gnl(&cmds, line);

--- a/oh_my_minishell/main.c
+++ b/oh_my_minishell/main.c
@@ -15,19 +15,31 @@ int main(int argc, char *argv[], char **envp)
 			g_flag[CTRL_BS] = 0;
 		else
 			ft_putstr_fd("minishell$ ",1);
+		// while (read(0, &c, 1) !=0 && c != '\n' )
+		// {
+		// 	// printf("value:%c\n", c);
+		// 	ft_addchr(&line, c);
+		// 	if (!g_flag[CTRL_D] && !line[0])
+		// 	{
+		// 		ft_putendl_fd("exit", 1);
+		// 		exit(0);
+		// 	}
+		// 	g_flag[CTRL_D] = 1;
+		// }
 		while (!(get_next_line(0, &line)))
 		{
-			if (!g_flag[CTRL_D] && !line[0])
+			if (!line[0])
 			{
 				ft_putendl_fd("exit", 1);
 				exit(0);
 			}
-			g_flag[CTRL_D] = 1;
+			// g_flag[CTRL_D] = 1;
 		}
 		ft_memset(g_flag, 0, sizeof(int) * F_END);
 		get_commands_from_gnl(&cmds, line);
 		execute_multi_commands(cmds);
 		free(line);
+		line = NULL;
 		ft_lstclear(&cmds, NULL);
 	}
 	minishell_exit(cmds);


### PR DESCRIPTION
1. g_flag[CTRL_D]는 사실상 쓰지 않는 값이여서 main 함수에서 제외시킴

2. CTRL+D를 제대로 처리하기 위해, get_next_line이 아니라 read함수로 읽는 것으로 바꿈(Thanks to @ykoh presenting idea)

```c
while (read(0, &c, 1) && c != '\n')
{
    ft_addchr(&line, c);
 }
 if (c == '\0')
{
     ft_putendl_fd("exit", 1);
     minishell_exit(cmds); exit(0);
}
   		
// while (!(get_next_line(0, &line)))
// {
// 	if (!line[0])
// 	{
// 		ft_putendl_fd("exit", 1);
// 		exit(0);
// 	}
// }
```
