### PR TITLE
Solve the issue #68

### DIFF
--- a/oh_my_minishell/check_command.c
+++ b/oh_my_minishell/check_command.c
@@ -109,7 +109,7 @@ static void	ft_execve(const char *path, char *const argv[], char *const envp[])
 		}
 	}
 	else
-		waitpid(pid, &g_status, 0);
+		waitpid(pid, NULL, 0);
 }
 
 void		check_command(char *cmd, char *argv[], char *envp[])

--- a/oh_my_minishell/signal.c
+++ b/oh_my_minishell/signal.c
@@ -3,6 +3,13 @@
 void	catch_sigint(int pid)
 {
 	(void)pid;
+	pid = waitpid(-1, &g_status, WNOHANG);
+	if (!pid)
+	{
+		g_status = 130 * 256;
+	}
+	else
+		g_status = 1 * 256;
 	ft_putstr_fd("\nminishell$ ", 1);
 	g_flag[CTRL_BS] = 1;
 }
@@ -11,7 +18,12 @@ void	catch_sigquit(int pid)
 {
 	pid = waitpid(-1, &g_status, WNOHANG);
 	if (!pid)
+	{
 		ft_putstr_fd("Quit: 3\n", 1);
+		g_status = 130 * 256;
+	}
+	else
+		g_status = 1 * 256;
 	g_flag[CTRL_Q] = 1;
 	// else
 	// 	ft_putstr_fd("\nQuit: 3", 1);

--- a/oh_my_minishell/signal.c
+++ b/oh_my_minishell/signal.c
@@ -20,10 +20,10 @@ void	catch_sigquit(int pid)
 	if (!pid)
 	{
 		ft_putstr_fd("Quit: 3\n", 1);
-		g_status = 130 * 256;
+		g_status = 131 * 256;
 	}
 	else
-		g_status = 1 * 256;
+		g_status = 0 * 256;
 	g_flag[CTRL_Q] = 1;
 	// else
 	// 	ft_putstr_fd("\nQuit: 3", 1);


### PR DESCRIPTION
issue #68 문제를 해결함.
다만 해결하는 과정에서 알게된 것은 `waitpid(pid, &g_status, 0)`에서 g_status으로 종료조건을 스스로 가져오기때문에 g_status 값은 알아서 배정된다고 이해하고 있었지만,
그러나 ^D. ^\, ^C 로 종료시에 g_status 는 0 값을 가졌다. 그래서 signal.c 에서 g_status를 수정해도, 코드의 실행 순서상 g_status가 0으로 덮혀졌다. 따라서  `ft_execve` 함수에서 `waitpid(pid, &g_status, 0)` 을 `waitpid(pid, NULL, 0)` 로 바꿔주었다.
issue #68 은 해결되었으나, 다른 부분에서 문제가 생길 수 있는 지, 다른 사람들의 확인이 필요함!