### PR TITLE
fxd quote in echo, fxd wrong env segfault in echo

### DIFF
--- a/oh_my_minishell/execute_echo.c
+++ b/oh_my_minishell/execute_echo.c
@@ -43,6 +43,8 @@ int execute_echo(const char *path, char *const argv[], char *const envp[])
 	skip_n_option(one_cmd_trimed, &i, &flag_n);
 	/* 여기서 큰 따옴표, 작은 따옴표 처리 */
 	echo_line = refine_line(one_cmd_trimed);
+	if (echo_line == NULL)
+		return (0);
 	while (echo_line[i] != '\0')
 	{
 		ft_putchar_fd(echo_line[i], 1);

--- a/oh_my_minishell/refine_line_b.c
+++ b/oh_my_minishell/refine_line_b.c
@@ -2,7 +2,10 @@
 
 void back_slash(char *buff, char *line, t_var *v)
 {
+	/* 큰 따옴표 바깥에 있으면 무시 백슬래쉬를 무시하고 그 뒤에 문자를 넣는다 */
 	if (v->flag_bq == 0)
+		(v->i)++;
+	else if (v->flag_bq == 1 && line[(v->i) + 1] == '"')
 		(v->i)++;
 	buff[v->k] = line[v->i];
 	(v->k)++;


### PR DESCRIPTION
echo "\""  다시 가능하게 함.

echo "$sdfdsfsdfsdf" 리스트에 없는 환경변수 했을 경우, 환경변수 에러 라는 경고문 을 띄우는 것으로 바꾸고, 세그폴트 고침