### PR TITLE
Fix leaks problem '|' '||' also norm check

### DIFF
--- a/oh_my_minishell/Makefile
+++ b/oh_my_minishell/Makefile
@@ -58,7 +58,7 @@ fclean	:	clean
 			$(RM) $(NAME)
 
 debug	:
-			$(CC) $(CFLAGS) libft/*.c gnl/*.c *.c -o minishell
+			$(CC) $(CFLAGS) libft/*.c gnl/*.c *.c -o minishell -g
 
 re		:	fclean all
 

--- a/oh_my_minishell/execute_commands.c
+++ b/oh_my_minishell/execute_commands.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execute_commands.c                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jikang <jikang@student.42seoul.kr>         +#+  +:+       +#+        */
+/*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/21 15:17:21 by jikang            #+#    #+#             */
-/*   Updated: 2021/01/22 01:51:24 by jikang           ###   ########.fr       */
+/*   Updated: 2021/01/23 12:46:06 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,6 +28,8 @@ static void	error_except(void)
 
 static int	check_delimeter(char **str)
 {
+	if (g_except[SYNTAX] == '|')
+		return (-1);
 	if (str[0] == NULL)
 	{
 		g_except[SYNTAX] = '|';

--- a/oh_my_minishell/split_pipe.c
+++ b/oh_my_minishell/split_pipe.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   split_pipe.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jikang <jikang@student.42seoul.kr>         +#+  +:+       +#+        */
+/*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/20 23:35:17 by jikang            #+#    #+#             */
-/*   Updated: 2021/01/21 01:35:46 by jikang           ###   ########.fr       */
+/*   Updated: 2021/01/23 12:57:25 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,10 +55,15 @@ void		check_pipe(int *buff, char *substr, t_var *v)
 	{
 		if (substr[v->i] == '|')
 		{
-			if (v->flag_bq == 0 && v->flag_sq == 0 && v->flag_pipe == 0)
+			if (v->flag_bq == 0 && v->flag_sq == 0)
 			{
+				if (v->i == 0 || substr[v->i - 1] == '|')
+				{
+					v->i++;
+					g_except[SYNTAX] = '|';
+					continue;
+				}
 				buff[(v->k)++] = v->i;
-				v->flag_pipe = 1;
 			}
 		}
 		else
@@ -67,7 +72,6 @@ void		check_pipe(int *buff, char *substr, t_var *v)
 				change_flag(&(v->flag_bq));
 			else if (substr[v->i] == '\'')
 				change_flag(&(v->flag_sq));
-			v->flag_pipe = 0;
 		}
 		(v->i)++;
 	}

--- a/oh_my_minishell/utils_b.c
+++ b/oh_my_minishell/utils_b.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   utils_b.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jikang <jikang@student.42seoul.kr>         +#+  +:+       +#+        */
+/*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/21 01:51:44 by jikang            #+#    #+#             */
-/*   Updated: 2021/01/21 15:04:53 by jikang           ###   ########.fr       */
+/*   Updated: 2021/01/23 12:54:40 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,8 +60,6 @@ char		*ft_strdup_by_index(char *str, int start, int end)
 
 	if (str == NULL || start < 0 || start > end || ft_strlen(str) < end)
 		return (0);
-	if (start == end)
-		ft_strdup(" ");
 	new = malloc(sizeof(char) * (end - start + 2));
 	i = start;
 	j = 0;


### PR DESCRIPTION
**"|", "||" 의 메모리 릭을 잡음**

특징
1. v->flag_pipe 를 사용하지않음.
2. char		*ft_strdup_by_index(char *str, int start, int end) 에서
  if (start == end) ft_strdup("") 를 삭제함.

get_param()->semi_array 처럼 `buff` 에 나누는 기능을하는 파이프의 인덱스 번호를 넘겨주는 것으로 보임.
다만 "|" 의 경우 에는 나눠지는 기능을 하는 파이프로 보기 어려운데 pipe_num = 1 을 값으로 가짐
이 경우에는 이후에 아마 2번에서 return (ft_strdup(""))으로 써주었다면 합당한 처리를 해주는 것으로 보이나,
"|||" "||"의 경우에 문제가 생김
예를들면, "||" 의 경우에도 pipe_num = 1 을 값으로 가짐
그래서 나는 두 경우 모두 자르는 기능을 하는 파이프가 아니라고 생각해서 buff에 담아두지 않는식으로 코드를 바꾸어보았음