### PR TITLE
Fix export double quote issue

### DIFF
--- a/oh_my_minishell/Makefile
+++ b/oh_my_minishell/Makefile
@@ -36,7 +36,8 @@ SRCS		=	gnl/get_next_line.c\
 				execute_cd_utils.c\
 				redirection_utils.c\
 				init.c\
-				exit.c
+				exit.c\
+				ft_split_minishell.c
 
 NAME		=	minishell
 LIBFT		=	libft

--- a/oh_my_minishell/ft_split_minishell.c
+++ b/oh_my_minishell/ft_split_minishell.c
@@ -1,0 +1,121 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_split_minishell.c                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2021/01/27 03:57:15 by yunslee           #+#    #+#             */
+/*   Updated: 2021/01/27 04:37:55 by yunslee          ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static size_t		split_len(const char *s, char c)
+{
+	unsigned int i;
+	char flag_quotes;
+
+	i = 0;
+	flag_quotes = 0;
+	while ((s[i] && s[i] != c) || (flag_quotes & 0x3))
+	{
+		if (s[i] == '\'')
+			flag_quotes ^= 1;
+		if (s[i] == '\"')
+			flag_quotes ^= 2;
+		i++;
+	}
+	return (i);
+}
+
+static unsigned int	size_array(const char *str, char c)
+{
+	int size;
+	int i;
+	char flag_quotes;
+
+	i = 0;
+	size = 0;
+	flag_quotes = 0;
+	if (str[0] == '\0')
+		return (size);
+	if (str[0] != c)
+		size += 1;
+	while (str[i])
+	{
+		if (str[i] == '\'')
+			flag_quotes ^= 1;
+		if (str[i] == '\"')
+			flag_quotes ^= 2;
+		if ((str[i] == c && str[i + 1] != c) && str[i + 1] != 0 &&
+				(flag_quotes ^ 0x1) && (flag_quotes ^ 0x2))
+			size++;
+		i++;
+	}
+	return (size);
+}
+
+static int			input_parts(char *dst, const char *src, char c, int i)
+{
+	int j;
+	char flag_quotes;
+
+	j = 0;
+	flag_quotes = 0;
+	while ((src[i] && src[i] != c) || (flag_quotes & 0x3))
+	{
+		if (src[i] == '\'')
+			flag_quotes ^= 1;
+		if (src[i] == '\"')
+			flag_quotes ^= 2;
+		dst[j] = src[i];
+		j++;
+		i++;
+	}
+	dst[j] = '\0';
+	return (i);
+}
+
+static void			free_all(char **split)
+{
+	char **split_init;
+
+	split_init = split;
+	while (*split != NULL)
+	{
+		free(*split);
+		split++;
+	}
+	free(split_init);
+}
+
+char				**ft_split_minishell(char const *s, char c)
+{
+	unsigned int	i;
+	unsigned int	array_size;
+	unsigned int	row;
+	char			**split;
+
+	i = 0;
+	row = 0;
+	array_size = size_array(s, c);
+	if (NULL == (split = (char**)malloc(sizeof(char *) * (array_size + 1))))
+		return (NULL);
+	while (row < array_size)
+	{
+		while (s[i] == c)
+			i++;
+		if (NULL == (split[row] = malloc(sizeof(char) *
+									(split_len((s + i), c) + 1))))
+		{
+			free_all(split);
+			return (NULL);
+		}
+		i = input_parts(split[row], s, c, i);
+		row++;
+	}
+	split[array_size] = NULL;
+	return (split);
+}

--- a/oh_my_minishell/minishell.h
+++ b/oh_my_minishell/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jikang <jikang@student.42seoul.kr>         +#+  +:+       +#+        */
+/*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/21 16:09:05 by jikang            #+#    #+#             */
-/*   Updated: 2021/01/23 02:05:20 by jikang           ###   ########.fr       */
+/*   Updated: 2021/01/27 04:30:27 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -355,4 +355,9 @@ int					msg_invalid(char *program, char *cmd,
 
 void				unseal_firstquotes(char **splited);
 
+/*
+**	ft_split_minishell.c
+*/
+
+char				**ft_split_minishell(char const *s, char c);
 #endif

--- a/oh_my_minishell/pipe.c
+++ b/oh_my_minishell/pipe.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pipe.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jikang <jikang@student.42seoul.kr>         +#+  +:+       +#+        */
+/*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/21 00:30:26 by yunslee           #+#    #+#             */
-/*   Updated: 2021/01/22 02:10:34 by jikang           ###   ########.fr       */
+/*   Updated: 2021/01/27 04:40:20 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,10 +14,12 @@
 
 static void	set_get_param(char *one_cmd)
 {
+	char **for_redirection;
 	get_param()->cmd_trimed = ft_strtrim(one_cmd, " ");
+	get_param()->cmd_splited = ft_split_minishell(get_param()->cmd_trimed, ' ');
 	parsing_redirect(get_param()->cmd_trimed);
-	get_param()->cmd_splited = ft_split(g_buf, ' ');
-	get_param()->cmd_redirect = splited_by_redirect(get_param()->cmd_splited,
+	for_redirection = ft_split(g_buf, ' ');
+	get_param()->cmd_redirect = splited_by_redirect(for_redirection,
 												&get_param()->symbol_array);
 }
 


### PR DESCRIPTION
2번 이슈 해결 한 것으로 보이는데 한 번 테스트 부탁함.

```
export a="a      b"
이렇게 들어오면
argv[0] export
argv[1] a="a        b"
argv[2] NULL
argv[0] export
argv[1] a=a        b
argv[2] NULL
```
이중에서 첫번째 경우로 get_param()-cmd_splited에 들어가도록 함