### PR TITLE
PR 요청

### DIFF
--- a/oh_my_minishell/check_command_utils.c
+++ b/oh_my_minishell/check_command_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   check_command_utils.c                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jikang <jikang@student.42seoul.kr>         +#+  +:+       +#+        */
+/*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/20 23:15:10 by yunslee           #+#    #+#             */
-/*   Updated: 2021/01/22 01:33:00 by jikang           ###   ########.fr       */
+/*   Updated: 2021/01/27 19:32:17 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -103,6 +103,7 @@ void			ft_execve(const char *path, char *const argv[],
 	struct stat	buf;
 
 	ft_bzero(&buf, sizeof(struct stat));
+	change_argv((char **)argv);
 	if (-1 == (pid = fork()))
 		return ;
 	if (pid == 0)

--- a/oh_my_minishell/execute_export_a.c
+++ b/oh_my_minishell/execute_export_a.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execute_export_a.c                                 :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ykoh <ykoh@student.42seoul.kr>             +#+  +:+       +#+        */
+/*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/21 05:17:00 by ykoh              #+#    #+#             */
-/*   Updated: 2021/01/21 05:17:01 by ykoh             ###   ########.fr       */
+/*   Updated: 2021/01/27 19:37:33 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -73,31 +73,13 @@ static int	is_exist(char *envp[], char argv[])
 	return (0);
 }
 
-static void	change_argv(const char *path, char **argv)
-{
-	int		i;
-	char	*tmp;
-
-	i = 0;
-	while (argv[i])
-	{
-		if ((tmp = refine_line(argv[i])))
-		{
-			free(argv[i]);
-			argv[i] = tmp;
-		}
-		i++;
-	}
-	(void)path;
-}
-
 int			execute_export(const char *path, char *const argv[],
 											char *const envp[])
 {
 	int		i;
 	int		j;
 
-	change_argv(path, (char **)++argv);
+	change_argv((char **)++argv);
 	if (vector_size((char **)argv))
 	{
 		i = 0;
@@ -119,4 +101,5 @@ int			execute_export(const char *path, char *const argv[],
 	if (g_status != 256)
 		g_status = 0;
 	return (0);
+	(void)path;
 }

--- a/oh_my_minishell/execute_unset.c
+++ b/oh_my_minishell/execute_unset.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   execute_unset.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ykoh <ykoh@student.42seoul.kr>             +#+  +:+       +#+        */
+/*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/21 05:17:20 by ykoh              #+#    #+#             */
-/*   Updated: 2021/01/21 05:17:21 by ykoh             ###   ########.fr       */
+/*   Updated: 2021/01/27 19:31:31 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,7 @@ static int	is_valid(char str[])
 	return (1);
 }
 
-static void	change_argv(char **argv)
+void	change_argv(char **argv)
 {
 	int		i;
 	char	*tmp;

--- a/oh_my_minishell/ft_split_minishell.c
+++ b/oh_my_minishell/ft_split_minishell.c
@@ -6,7 +6,7 @@
 /*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/27 03:57:15 by yunslee           #+#    #+#             */
-/*   Updated: 2021/01/27 04:37:55 by yunslee          ###   ########.fr       */
+/*   Updated: 2021/01/27 18:59:37 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,14 +17,21 @@ static size_t		split_len(const char *s, char c)
 	unsigned int i;
 	char flag_quotes;
 
-	i = 0;
 	flag_quotes = 0;
+	if (s[0] == '\'')
+		flag_quotes ^= 1;
+	if (s[0] == '\"')
+		flag_quotes ^= 2;
+	i = 1;
 	while ((s[i] && s[i] != c) || (flag_quotes & 0x3))
 	{
-		if (s[i] == '\'')
-			flag_quotes ^= 1;
-		if (s[i] == '\"')
-			flag_quotes ^= 2;
+		if (s[i - 1] != '\\')
+		{
+			if (s[i] == '\'')
+				flag_quotes ^= 1;
+			if (s[i] == '\"')
+				flag_quotes ^= 2;
+		}
 		i++;
 	}
 	return (i);
@@ -38,17 +45,25 @@ static unsigned int	size_array(const char *str, char c)
 
 	i = 0;
 	size = 0;
-	flag_quotes = 0;
 	if (str[0] == '\0')
 		return (size);
 	if (str[0] != c)
-		size += 1;
+		size = 1;
+	flag_quotes = 0;
+	if (str[0] == '\'')
+		flag_quotes ^= 1;
+	if (str[0] == '\"')
+		flag_quotes ^= 2;
+	i = 1;
 	while (str[i])
 	{
-		if (str[i] == '\'')
-			flag_quotes ^= 1;
-		if (str[i] == '\"')
-			flag_quotes ^= 2;
+		if (str[i - 1] != '\\')
+		{
+			if (str[i] == '\'')
+				flag_quotes ^= 1;
+			if (str[i] == '\"')
+				flag_quotes ^= 2;
+		}
 		if ((str[i] == c && str[i + 1] != c) && str[i + 1] != 0 &&
 				(flag_quotes ^ 0x1) && (flag_quotes ^ 0x2))
 			size++;
@@ -66,10 +81,13 @@ static int			input_parts(char *dst, const char *src, char c, int i)
 	flag_quotes = 0;
 	while ((src[i] && src[i] != c) || (flag_quotes & 0x3))
 	{
-		if (src[i] == '\'')
-			flag_quotes ^= 1;
-		if (src[i] == '\"')
-			flag_quotes ^= 2;
+		if (i != 0 && src[i - 1] != '\\')
+		{
+			if (src[i] == '\'')
+				flag_quotes ^= 1;
+			if (src[i] == '\"')
+				flag_quotes ^= 2;
+		}
 		dst[j] = src[i];
 		j++;
 		i++;

--- a/oh_my_minishell/minishell.h
+++ b/oh_my_minishell/minishell.h
@@ -6,7 +6,7 @@
 /*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/21 16:09:05 by jikang            #+#    #+#             */
-/*   Updated: 2021/01/27 04:30:27 by yunslee          ###   ########.fr       */
+/*   Updated: 2021/01/27 19:39:38 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -360,4 +360,10 @@ void				unseal_firstquotes(char **splited);
 */
 
 char				**ft_split_minishell(char const *s, char c);
+
+/*
+**	execute_unset.c
+*/
+
+void				change_argv(char **argv);
 #endif

--- a/oh_my_minishell/pipe.c
+++ b/oh_my_minishell/pipe.c
@@ -6,17 +6,23 @@
 /*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/21 00:30:26 by yunslee           #+#    #+#             */
-/*   Updated: 2021/01/27 04:40:20 by yunslee          ###   ########.fr       */
+/*   Updated: 2021/01/27 19:09:40 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+#include <stdio.h>
 
 static void	set_get_param(char *one_cmd)
 {
 	char **for_redirection;
+
 	get_param()->cmd_trimed = ft_strtrim(one_cmd, " ");
 	get_param()->cmd_splited = ft_split_minishell(get_param()->cmd_trimed, ' ');
+	// for (size_t i = 0; get_param()->cmd_splited[i]; i++)
+	// {
+	// 	printf("%s\n", get_param()->cmd_splited[i]);
+	// }
 	parsing_redirect(get_param()->cmd_trimed);
 	for_redirection = ft_split(g_buf, ' ');
 	get_param()->cmd_redirect = splited_by_redirect(for_redirection,


### PR DESCRIPTION
1. echo asdf ;; echo hello
~2. export a="a   d"~
3. echo hello > file1 bye
4. echo "$HOMEaa" # 환경변수 에러 or 똑같이 출력
---
이번 PR로 해결된 점, 바뀐점
1. 2번 문제 해결  -> get_param()->cmd_splited 에 배정되는 값 자체가 바뀌었기 때문에 check_command 에서 argv로 값을 받아서 다양하게 활용할 수 있을 것으로 보임
2. mkdir "a  b" 도   `a   b` 폴더 생성
3. `echo "aaa`  이렇게 쌍따움표 안닫아주면 세그폴트 나지만, 이 경우는 서브젝트에서 고려하지않는 것으로 앎

남은 과제
아직까지는 파이프를 담는 삼중 포인터는 새로 변경된 cmd_splited를 사용하지않고 이전 버전의 cmd_splited를 temp에 담아서 사용하고 있다. 리디렉션 문제와 함께 리디렉션 파싱 파트가 전부 바뀌어야 할 것 같다.
