### PR TITLE
리디렉션 개선

### DIFF
--- a/oh_my_minishell/pipe.c
+++ b/oh_my_minishell/pipe.c
@@ -6,7 +6,7 @@
 /*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/21 00:30:26 by yunslee           #+#    #+#             */
-/*   Updated: 2021/01/29 00:46:05 by yunslee          ###   ########.fr       */
+/*   Updated: 2021/01/29 16:07:34 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,19 +15,16 @@
 
 static void	set_get_param(char *one_cmd)
 {
-	char **for_redirection;
-
 	get_param()->cmd_trimed = ft_strtrim(one_cmd, " ");
-	get_param()->cmd_splited = ft_split_minishell(get_param()->cmd_trimed, ' ');
+	parsing_redirect(get_param()->cmd_trimed);
+	// printf("g_buf:%s\n", g_buf);
+	get_param()->cmd_splited = ft_split_minishell(g_buf, ' ');
 	// for (size_t i = 0; get_param()->cmd_splited[i]; i++)
 	// {
 	// 	printf("%s\n", get_param()->cmd_splited[i]);
 	// }
-	parsing_redirect(get_param()->cmd_trimed);
-	for_redirection = ft_split(g_buf, ' ');
-	get_param()->cmd_redirect = splited_by_redirect(for_redirection,
+	get_param()->cmd_redirect = splited_by_redirect(get_param()->cmd_splited,
 												&get_param()->symbol_array);
-	free_split(for_redirection);
 }
 
 int			execute_command_nopipe(char *one_cmd)

--- a/oh_my_minishell/redirection.c
+++ b/oh_my_minishell/redirection.c
@@ -6,7 +6,7 @@
 /*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/21 01:25:54 by yunslee           #+#    #+#             */
-/*   Updated: 2021/01/21 17:14:07 by yunslee          ###   ########.fr       */
+/*   Updated: 2021/01/29 16:09:15 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,15 +19,15 @@ static int	is_redirect(char *str, t_index *index)
 	i = 0;
 	if (str == NULL)
 		return (-1);
-	while (str[i])
-	{
-		if (str[i] == '\'')
-			index->f_quote ^= 1;
-		if (str[i++] == '\"')
-			index->f_quote ^= 2;
-	}
-	if (index->f_quote & 1 || index->f_quote & 2)
-		return (FALSE);
+	// while (str[i])
+	// {
+	// 	if (str[i] == '\'')
+	// 		index->f_quote ^= 1;
+	// 	if (str[i++] == '\"')
+	// 		index->f_quote ^= 2;
+	// }
+	// if (index->f_quote & 1 || index->f_quote & 2)
+	// 	return (FALSE);
 	if (str[0] == '>' || str[0] == '<')
 	{
 		if (!ft_strncmp(str, ">>", 3))
@@ -39,6 +39,7 @@ static int	is_redirect(char *str, t_index *index)
 		return (ERROR);
 	}
 	return (FALSE);
+	(void) index;
 }
 
 static int	redirect_num(char **one_cmd_splited, t_index *index)

--- a/oh_my_minishell/redirection_utils.c
+++ b/oh_my_minishell/redirection_utils.c
@@ -6,7 +6,7 @@
 /*   By: yunslee <yunslee@student.42seoul.kr>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2021/01/21 03:40:40 by yunslee           #+#    #+#             */
-/*   Updated: 2021/01/21 17:05:31 by yunslee          ###   ########.fr       */
+/*   Updated: 2021/01/29 15:11:12 by yunslee          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,29 +53,41 @@ void		input_symbol(char **split, char *symbol_array, t_index *index)
 		symbol_array[index->z++] = ERROR;
 }
 
+void		input_space_between_redirect(char *str, int *i, int *k, char *flag_quotes)
+{
+	if ((str[*i] == '<' || str[*i] == '>') &&
+			(str[*i + 1] == '<' || str[*i + 1] == '>'))
+	{
+		return ;
+	}
+	else if ((str[*i] == '<' || str[*i] == '>') &&
+				(str[(*i) + 1] != '>' && str[(*i) + 1] != '<') &&
+					(*flag_quotes ^ 0x1 && *flag_quotes ^ 0x2))
+		g_buf[(*k)++] = ' ';
+	else if ((str[*i] != '<' && str[*i] != '>') &&
+				(str[(*i) + 1] == '>' || str[(*i) + 1] == '<') &&
+					(*flag_quotes ^ 0x1 && *flag_quotes ^ 0x2))
+		g_buf[(*k)++] = ' ';
+}
+
 int			parsing_redirect(char *str)
 {
 	int	i;
 	int	k;
+	char flag_quotes;
 
+	flag_quotes = 0;
 	ft_memset(g_buf, 0, 1000);
 	i = 0;
 	k = 0;
 	while (str[i] != '\0')
 	{
+		if (i != 0 && i!= 1 && str[i - 1] != '\\')
+			change_flag_quotes(str, i, &flag_quotes);
+		else if (i != 0 && i !=1 && str[i - 1] == '\\' && str[i - 2] == '\\')
+			change_flag_quotes(str, i, &flag_quotes);
 		g_buf[k++] = str[i];
-		if ((str[i] == '<' || str[i] == '>') &&
-				(str[i + 1] == '<' || str[i + 1] == '>'))
-		{
-			i++;
-			continue;
-		}
-		else if ((str[i] == '<' || str[i] == '>') &&
-					(str[i + 1] != '>' && str[i + 1] != '<'))
-			g_buf[k++] = ' ';
-		else if ((str[i] != '<' && str[i] != '>') &&
-					(str[i + 1] == '>' || str[i + 1] == '<'))
-			g_buf[k++] = ' ';
+		input_space_between_redirect(str, &i, &k, &flag_quotes);
 		i++;
 	}
 	return (1);


### PR DESCRIPTION
cmd_split를 ft_split_minishell 함수로 파싱함에 따라서, splited_by_redirection함수도 약간의 수정을 통해, 가독성이 더 좋은 코드로 바꿀 수 있었음

**크게 바뀐점 : set_get_param()에서 char **for_redirection 변수를 쓰지 않아도 된다.**